### PR TITLE
Fix link handling

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -516,7 +516,7 @@ class _DefaultPageState extends State<DefaultPage> {
   void handleInitialLink(Uri link) {
     // Assume it's a username if there's only one segment (or two segments with the second empty, meaning the URI ends with /)
     if (link.pathSegments.length == 1 || (link.pathSegments.length == 2 && link.pathSegments.last.isEmpty)) {
-      Navigator.pushReplacementNamed(context, routeProfile,
+      Navigator.pushNamed(context, routeProfile,
           arguments: ProfileScreenArguments.fromScreenName(link.pathSegments.first));
       return;
     }
@@ -545,7 +545,7 @@ class _DefaultPageState extends State<DefaultPage> {
         var username = link.pathSegments[0];
         var statusId = link.pathSegments[2];
 
-        Navigator.pushReplacementNamed(context, routeStatus,
+        Navigator.pushNamed(context, routeStatus,
             arguments: StatusScreenArguments(
               id: statusId,
               username: username,
@@ -561,8 +561,7 @@ class _DefaultPageState extends State<DefaultPage> {
 
       // https://twitter.com/i/topics/tweet/1447290060123033601
       if (segment2 == 'topics' && segment3 == 'tweet') {
-        Navigator.pushReplacementNamed(context, routeStatus,
-            arguments: StatusScreenArguments(id: segment4, username: null));
+        Navigator.pushNamed(context, routeStatus, arguments: StatusScreenArguments(id: segment4, username: null));
         return;
       }
     }


### PR DESCRIPTION
This PR changes how QuaX handles shared links. Right now there are a couple of problems.
- If the app is already running and I open a link, it replaces the current view (rather than pushing a new navigation page). My expectation is that I would be able to press back to continue where I left off, but this doesn't work.
- Once I've opened one link in the app, I can't open any more.

I believe this all comes down to the usage of `pushReplacementNamed`, which replaces the current route rather than pushing a new one. Changing it to `pushNamed` seems to do the trick. Please let me know if this change would have any other effects that I'm not aware of.

### Before

https://github.com/user-attachments/assets/35aa10a2-2def-4514-9b27-0e02b109688a

### After

https://github.com/user-attachments/assets/1c54dc7e-00d4-49e1-b04a-29c8ca60d216