### PR TITLE
Add option to display the absolute timestamp of all tweets

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -43,6 +43,7 @@ const optionThemeColor = 'theme.color';
 const optionThemeTrueBlack = 'theme.true_black';
 const optionThemeTrueBlackTweetCards = 'theme.true_black_tweet_cards';
 const optionShowNavigationLabels = 'theme.show_navigation_labels';
+const optionUseAbsoluteTimestamp = "option.absolute_timestamp";
 
 const themeColors = {
   'red': Colors.red,

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -492,5 +492,9 @@
   "functionality_unsupported": "Diese Funktion wird von Twitter nicht mehr unterstützt!",
   "@functionality_unsupported": {},
   "add_subscriptions": "Abonnements hinzufügen",
-  "@add_subscriptions": {}
+  "@add_subscriptions": {},
+  "use_absolute_timestamp": "Absoluter Zeitstempel",
+  "@use_absolute_timestamp": {},
+  "use_absolute_timestamp_description": "Zeige absoluten Zeitstempel bei Tweets",
+  "@use_absolute_timestamp_description": {}
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -453,6 +453,8 @@
   "allow_background_play_description": "Allow to play in the background",
   "allow_background_play_other_apps": "Other apps in background",
   "allow_background_play_other_apps_description": "Allow other apps to play in the background",
+  "use_absolute_timestamp": "Use absolute timestamp",
+  "use_absolute_timestamp_description": "Display absolute timestamp on tweet",
   "option_confirm_close_label": "Confirm close",
   "option_confirm_close_description": "Confirm when closing the app",
   "more_info": "More info",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -217,6 +217,7 @@ Future<void> main() async {
     optionThemeTrueBlackTweetCards: true,
     optionShowNavigationLabels: false,
     optionTweetsHideSensitive: true,
+    optionUseAbsoluteTimestamp: false,
     optionUserTrendsLocations: jsonEncode({
       'active': {'name': 'Worldwide', 'woeid': 1},
       'locations': [

--- a/lib/settings/_general.dart
+++ b/lib/settings/_general.dart
@@ -172,6 +172,11 @@ class SettingsGeneralFragment extends StatelessWidget {
                 ),
               ]),
           PrefSwitch(
+            pref: optionUseAbsoluteTimestamp,
+            title: Text(L10n.of(context).use_absolute_timestamp),
+            subtitle: Text(L10n.of(context).use_absolute_timestamp_description),
+          ),
+          PrefSwitch(
             pref: optionMediaDefaultMute,
             title: Text(L10n.of(context).mute_videos),
             subtitle: Text(L10n.of(context).mute_video_description),

--- a/lib/tweet/tweet.dart
+++ b/lib/tweet/tweet.dart
@@ -549,7 +549,7 @@ class TweetTileState extends State<TweetTile> with SingleTickerProviderStateMixi
                               ],
                               if (createdAt != null)
                                 DefaultTextStyle(
-                                    style: theme.textTheme.bodySmall!, child: Timestamp(timestamp: createdAt))
+                                    style: theme.textTheme.bodySmall!, child: Timestamp(timestamp: createdAt, absoluteTimestamp: prefs.get(optionUseAbsoluteTimestamp)))
                             ],
                           ),
                           // Profile picture

--- a/lib/ui/dates.dart
+++ b/lib/ui/dates.dart
@@ -10,15 +10,18 @@ String createRelativeDate(DateTime dateTime) {
 
 class Timestamp extends StatefulWidget {
   final DateTime? timestamp;
+  final bool absoluteTimestamp;
 
-  const Timestamp({super.key, required this.timestamp});
+  const Timestamp({super.key, required this.timestamp, this.absoluteTimestamp = false});
 
   @override
-  State<Timestamp> createState() => _TimestampState();
+  State<Timestamp> createState() => _TimestampState(useRelativeTimestamp: !absoluteTimestamp);
 }
 
 class _TimestampState extends State<Timestamp> {
-  bool _useRelativeTimestamp = true;
+  bool useRelativeTimestamp;
+
+  _TimestampState({this.useRelativeTimestamp = true});
 
   String formattedTime = '';
 
@@ -28,7 +31,11 @@ class _TimestampState extends State<Timestamp> {
 
     var timestamp = widget.timestamp;
     if (timestamp != null) {
-      formattedTime = createRelativeDate(timestamp);
+      if (useRelativeTimestamp) {
+        formattedTime = createRelativeDate(timestamp);
+      } else {
+        formattedTime = absoluteDateFormat.format(timestamp);
+      }
     }
   }
 
@@ -43,13 +50,13 @@ class _TimestampState extends State<Timestamp> {
       child: Text(formattedTime),
       onTap: () {
         setState(() {
-          if (_useRelativeTimestamp) {
+          if (useRelativeTimestamp) {
             formattedTime = createRelativeDate(timestamp);
           } else {
             formattedTime = absoluteDateFormat.format(timestamp);
           }
 
-          _useRelativeTimestamp = !_useRelativeTimestamp;
+          useRelativeTimestamp = !useRelativeTimestamp;
         });
       },
     );


### PR DESCRIPTION
Add an option to display an absolute timestamp on all tweets.

Previously, with relative timestamp:
<img width="1080" height="2160" alt="Screenshot_20251129-153456_QuaX (Debug)" src="https://github.com/user-attachments/assets/4c27ee87-47e4-47f6-bfcd-4b1f8e8a02dc" />

Afterwards with absolute timestamp:
<img width="1080" height="2160" alt="Screenshot_20251129-153537_QuaX (Debug)" src="https://github.com/user-attachments/assets/f4ab06a0-44bf-4962-ade2-7aa78a15ebca" />

Changes in settings:
<img width="801" height="1602" alt="Screenshot_20251129-153550_QuaX (Debug)" src="https://github.com/user-attachments/assets/70a6551f-8285-464f-998e-44179bcbb06a" />

I don't know if I did everything correctly and as it is intended. If there are some issues with this PR / changes, please let me know!
