### PR TITLE
Fix initial link handling

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -583,12 +583,6 @@ class _DefaultPageState extends State<DefaultPage> {
 
     final appLinks = AppLinks();
 
-    appLinks.getInitialLink().then((link) {
-      if (link != null) {
-        handleInitialLink(link);
-      }
-    });
-
     // Attach a listener to the stream
     _sub = appLinks.uriLinkStream.listen((link) => handleInitialLink(link), onError: (err) {
       // TODO: Handle exception by warning the user their action did not succeed


### PR DESCRIPTION
Hey I discovered a small issue with link handling that I think was introduced in #69. When the app is closed and it handles a link, it ends up pushing the same navigation page twice. It looks like it's handling the same action twice (once via getting the startup link and once via the stream listener). Most likely this is why it was using `pushReplacementNamed` before, to essentially cover up this issue.

However, it turns out that the stream always has the link, so I just removed the initial handling and it seems to work fine. I also re-tested the other scenarios that I was trying to fix previously and things seem to work fine still, but please let me know if you see any issues.

### Before

https://github.com/user-attachments/assets/0c908883-21e9-4ef5-9b19-56b2bc84d0ba

### After

https://github.com/user-attachments/assets/5f76ba89-10b7-475b-8f5d-e56fa15d5265