### PR TITLE
Display absolute timestamp of tweets in local timezone

### DIFF
--- a/lib/ui/dates.dart
+++ b/lib/ui/dates.dart
@@ -19,9 +19,9 @@ class Timestamp extends StatefulWidget {
 }
 
 class _TimestampState extends State<Timestamp> {
-  bool useRelativeTimestamp;
+  bool _useRelativeTimestamp;
 
-  _TimestampState({this.useRelativeTimestamp = true});
+  _TimestampState({useRelativeTimestamp = true}) : _useRelativeTimestamp = useRelativeTimestamp;
 
   String formattedTime = '';
 
@@ -31,10 +31,10 @@ class _TimestampState extends State<Timestamp> {
 
     var timestamp = widget.timestamp;
     if (timestamp != null) {
-      if (useRelativeTimestamp) {
+      if (_useRelativeTimestamp) {
         formattedTime = createRelativeDate(timestamp);
       } else {
-        formattedTime = absoluteDateFormat.format(timestamp);
+        formattedTime = absoluteDateFormat.format(timestamp.toLocal());
       }
     }
   }
@@ -50,13 +50,13 @@ class _TimestampState extends State<Timestamp> {
       child: Text(formattedTime),
       onTap: () {
         setState(() {
-          if (useRelativeTimestamp) {
+          if (_useRelativeTimestamp) {
             formattedTime = createRelativeDate(timestamp);
           } else {
-            formattedTime = absoluteDateFormat.format(timestamp);
+            formattedTime = absoluteDateFormat.format(timestamp.toLocal());
           }
 
-          useRelativeTimestamp = !useRelativeTimestamp;
+          _useRelativeTimestamp = !_useRelativeTimestamp;
         });
       },
     );


### PR DESCRIPTION
This PR addresses #74 and displays the the absolute timestamp of all tweets in the local timezone.

Also it makes the variable `useRelativeTimestamp` private again since i discovered how to use constructors in dart^^
If there is something I should change, please let me know :)

FWIW, I discovered during fixing this issue, that tapping on the timestamp-label on a tweet the timestamp switches from relative to absolute and vice-versa :). Maybe this could / should be documented somewhere? I think I used fritter / squawker a couple of years and didn't know about that feature :)