### PR TITLE
Re-implement basic support for the media tab

### DIFF
--- a/lib/client/client.dart
+++ b/lib/client/client.dart
@@ -376,6 +376,14 @@ class Twitter {
 
         replies
             .add(TweetChain(id: result['rest_id'] ?? result['tweet']['rest_id'], tweets: [tweet], isPinned: isPinned));
+      } else if (entryId.startsWith('profile-grid-')) {
+        // We got a tweet queried from the media tab
+        for (var mediaTweet in entry['content']['items']) {
+          var result = mediaTweet['item']['itemContent']['tweet_results']['result'];
+          TweetWithCard? tweet = TweetWithCard.fromGraphqlJson(result);
+          replies.add(
+              TweetChain(id: result['rest_id'] ?? result['tweet']['rest_id'], tweets: [tweet], isPinned: isPinned));
+        }
       }
 
       if (entryId.startsWith('cursor-bottom') || entryId.startsWith('cursor-showMore')) {
@@ -704,46 +712,44 @@ class Twitter {
       });
 
       defaultUserTweetsParam["filedToggles"] = jsonEncode({"withArticlePlainText": false});
-    }
-    else if (type == "media") {
-      defaultUserTweetsParam["features"] = jsonEncode(
-          {
-            "rweb_video_screen_enabled": false,
-            "payments_enabled": false,
-            "profile_label_improvements_pcf_label_in_post_enabled": true,
-            "responsive_web_profile_redirect_enabled": false,
-            "rweb_tipjar_consumption_enabled": true,
-            "verified_phone_label_enabled": false,
-            "creator_subscriptions_tweet_preview_api_enabled": true,
-            "responsive_web_graphql_timeline_navigation_enabled": true,
-            "responsive_web_graphql_skip_user_profile_image_extensions_enabled": false,
-            "premium_content_api_read_enabled": false,
-            "communities_web_enable_tweet_community_results_fetch": true,
-            "c9s_tweet_anatomy_moderator_badge_enabled": true,
-            "responsive_web_grok_analyze_button_fetch_trends_enabled": false,
-            "responsive_web_grok_analyze_post_followups_enabled": true,
-            "responsive_web_jetfuel_frame": true,
-            "responsive_web_grok_share_attachment_enabled": true,
-            "articles_preview_enabled": true,
-            "responsive_web_edit_tweet_api_enabled": true,
-            "graphql_is_translatable_rweb_tweet_is_translatable_enabled": true,
-            "view_counts_everywhere_api_enabled": true,
-            "longform_notetweets_consumption_enabled": true,
-            "responsive_web_twitter_article_tweet_consumption_enabled": true,
-            "tweet_awards_web_tipping_enabled": false,
-            "responsive_web_grok_show_grok_translated_post": false,
-            "responsive_web_grok_analysis_button_from_backend": true,
-            "creator_subscriptions_quote_tweet_preview_enabled": false,
-            "freedom_of_speech_not_reach_fetch_enabled": true,
-            "standardized_nudges_misinfo": true,
-            "tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled": true,
-            "longform_notetweets_rich_text_read_enabled": true,
-            "longform_notetweets_inline_media_enabled": true,
-            "responsive_web_grok_image_annotation_enabled": true,
-            "responsive_web_grok_imagine_annotation_enabled": true,
-            "responsive_web_grok_community_note_auto_translation_is_enabled": false,
-            "responsive_web_enhance_cards_enabled": false
-          });
+    } else if (type == "media") {
+      defaultUserTweetsParam["features"] = jsonEncode({
+        "rweb_video_screen_enabled": false,
+        "payments_enabled": false,
+        "profile_label_improvements_pcf_label_in_post_enabled": true,
+        "responsive_web_profile_redirect_enabled": false,
+        "rweb_tipjar_consumption_enabled": true,
+        "verified_phone_label_enabled": false,
+        "creator_subscriptions_tweet_preview_api_enabled": true,
+        "responsive_web_graphql_timeline_navigation_enabled": true,
+        "responsive_web_graphql_skip_user_profile_image_extensions_enabled": false,
+        "premium_content_api_read_enabled": false,
+        "communities_web_enable_tweet_community_results_fetch": true,
+        "c9s_tweet_anatomy_moderator_badge_enabled": true,
+        "responsive_web_grok_analyze_button_fetch_trends_enabled": false,
+        "responsive_web_grok_analyze_post_followups_enabled": true,
+        "responsive_web_jetfuel_frame": true,
+        "responsive_web_grok_share_attachment_enabled": true,
+        "articles_preview_enabled": true,
+        "responsive_web_edit_tweet_api_enabled": true,
+        "graphql_is_translatable_rweb_tweet_is_translatable_enabled": true,
+        "view_counts_everywhere_api_enabled": true,
+        "longform_notetweets_consumption_enabled": true,
+        "responsive_web_twitter_article_tweet_consumption_enabled": true,
+        "tweet_awards_web_tipping_enabled": false,
+        "responsive_web_grok_show_grok_translated_post": false,
+        "responsive_web_grok_analysis_button_from_backend": true,
+        "creator_subscriptions_quote_tweet_preview_enabled": false,
+        "freedom_of_speech_not_reach_fetch_enabled": true,
+        "standardized_nudges_misinfo": true,
+        "tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled": true,
+        "longform_notetweets_rich_text_read_enabled": true,
+        "longform_notetweets_inline_media_enabled": true,
+        "responsive_web_grok_image_annotation_enabled": true,
+        "responsive_web_grok_imagine_annotation_enabled": true,
+        "responsive_web_grok_community_note_auto_translation_is_enabled": false,
+        "responsive_web_enhance_cards_enabled": false
+      });
       defaultUserTweetsParam["filedToggles"] = jsonEncode({"withArticlePlainText": false});
     }
 
@@ -756,10 +762,9 @@ class Twitter {
     defaultUserTweetsParam["variables"] = json.encode(variables);
 
     late String path;
-    if(type == "media") {
+    if (type == "media") {
       path = "/i/api/graphql/36oKqyQ7E_9CmtONGjJRsA/UserMedia";
-    }
-    else {
+    } else {
       path = includeReplies
           ? "/i/api/graphql/T52C7z3XOxUTSsIn1sQ5MA/UserTweetsAndReplies"
           : '/i/api/graphql/2GIWTr7XwadIixZDtyXd4A/UserTweets';


### PR DESCRIPTION
This PR adds basic support so that the media-tab basically works again. It displays all the tweets containing any media again as standard tweets. There is no grid-view or anything similar implemented. I just wanted to bring back the basic feature although there may be still bugs since I just tried to 'reverse-engineer' the API based on 3 twitter-profiles :D.

This basically fixes #20. 

