### PR TITLE
Add option to always show full tweet contents

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -33,6 +33,8 @@ const optionShareBaseUrl = 'share_base_url';
 
 const optionDisableWarningsForUnrelatedPostsInFeed = 'disable_warnings_for_unrelated_posts_in_feed';
 
+const alwaysShowFullTweetContents = 'always_show_full_tweet_contents';
+
 const optionSubscriptionGroupsOrderByAscending = 'subscription_groups.order_by.ascending';
 const optionSubscriptionGroupsOrderByField = 'subscription_groups.order_by.field';
 const optionSubscriptionOrderByAscending = 'subscription.order_by.ascending';

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -463,6 +463,8 @@
   "disable_warnings_for_unrelated_posts_in_feed": "Disable warnings for unrelated posts in feed",
   "disable_warnings_for_unrelated_posts_in_feed_description": "X is known to sometimes show posts in feed from people you do not follow. This option disables the QuaX warning popup when this issue occurs.",
   "never_show_again": "Never show again",
-  "unknown_username": "Unknown username"
+  "unknown_username": "Unknown username",
+  "always_show_full_tweet_contents": "Always show full tweet contents",
+  "always_show_full_tweet_contents_description": "Always show the full contents of a tweet, even if it's long, without the \"Show more\" button"
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -208,6 +208,7 @@ Future<void> main() async {
     optionShouldCheckForUpdates: const String.fromEnvironment('app.flavor') == "fdroid" ? false : true,
     optionSubscriptionGroupsOrderByAscending: true,
     optionDisableWarningsForUnrelatedPostsInFeed: false,
+    alwaysShowFullTweetContents: false,
     optionSubscriptionGroupsOrderByField: 'name',
     optionSubscriptionOrderByAscending: true,
     optionSubscriptionOrderByField: 'name',

--- a/lib/settings/_general.dart
+++ b/lib/settings/_general.dart
@@ -234,6 +234,11 @@ class SettingsGeneralFragment extends StatelessWidget {
             subtitle: Text(L10n.of(context).disable_warnings_for_unrelated_posts_in_feed_description),
             pref: optionDisableWarningsForUnrelatedPostsInFeed,
           ),
+          PrefSwitch(
+            title: Text(L10n.of(context).always_show_full_tweet_contents),
+            subtitle: Text(L10n.of(context).always_show_full_tweet_contents_description),
+            pref: alwaysShowFullTweetContents,
+          ),
         ]),
       ),
     );

--- a/lib/tweet/_ExpandableTweetText.dart
+++ b/lib/tweet/_ExpandableTweetText.dart
@@ -4,7 +4,7 @@ import 'package:quax/generated/l10n.dart';
 class ExpandableTweetText extends StatefulWidget {
   final List<InlineSpan> textSpans;
   final VoidCallback? onTap;
-  final int maxLines;
+  final int? maxLines;
 
   const ExpandableTweetText({
     super.key,
@@ -23,6 +23,8 @@ class ExpandableTweetTextState extends State<ExpandableTweetText> {
   bool _textIsTruncated() {
     if (!mounted) return false;
 
+    if (widget.maxLines == null) return false;
+
     final painter = TextPainter(
       text: TextSpan(children: widget.textSpans),
       textDirection: TextDirection.ltr,
@@ -30,7 +32,7 @@ class ExpandableTweetTextState extends State<ExpandableTweetText> {
     );
 
     painter.layout(maxWidth: MediaQuery.of(context).size.width);
-    final res = painter.computeLineMetrics().length > widget.maxLines;
+    final res = painter.computeLineMetrics().length > widget.maxLines!;
     painter.dispose();
 
     return res;

--- a/lib/tweet/tweet.dart
+++ b/lib/tweet/tweet.dart
@@ -300,7 +300,7 @@ class TweetTileState extends State<TweetTile> with SingleTickerProviderStateMixi
             child: ExpandableTweetText(
               textSpans: displayRichText(_displayParts),
               onTap: () => !widget.tweetOpened ? onClickOpenTweet(tweet) : null,
-              maxLines: 8,
+              maxLines: PrefService.of(context).get(alwaysShowFullTweetContents) ? null : 8,
             ),
           ));
     }


### PR DESCRIPTION
Hey there! Recently I've gotten a little tired of always pressing "Show more" to expand long tweets, so I decided to add a new option (off by default) that allows users to always show the entirety of the tweet contents, even if it's long.

Let me know what you thinK!

### Demo

https://github.com/user-attachments/assets/53772c7e-8858-4848-8372-6a7a67dc2878