### PR TITLE
Fix a bug leading to stack traces appearing in app and improve display of quote tweets

### DIFF
--- a/lib/client/client.dart
+++ b/lib/client/client.dart
@@ -1144,6 +1144,9 @@ class TweetWithCard extends Tweet {
         result['quoted_status_result']['result'] != null &&
         result['quoted_status_result']['result']?['__typename'] != 'TweetWithVisibilityResults') {
       quotedStatus = TweetWithCard.fromGraphqlJson(result['quoted_status_result']['result']!);
+    } else if (result['quoted_status_result'] != null) {
+      // sometimes the quoted tweet is unavailable; this way we have a placeholder showing there was a tweet here
+      quotedStatus = TweetWithCard.tombstone({});
     }
 
     var resCore = result['core']?['user_results']?['result'];

--- a/lib/client/client.dart
+++ b/lib/client/client.dart
@@ -217,8 +217,6 @@ class Twitter {
       }
     }
 
-    Logger.detached("").info(result);
-
     var user = UserWithExtra.fromJson(
         {...result['legacy'], 'id_str': result['rest_id'], 'ext_is_blue_verified': result['is_blue_verified']});
     var pins = List<String>.from(result['legacy']['pinned_tweet_ids_str']);
@@ -1140,13 +1138,13 @@ class TweetWithCard extends Tweet {
       retweetedStatus = TweetWithCard.fromGraphqlJson(result['legacy']['retweeted_status_result']['result']!);
     }
 
-    if (result['quoted_status_result'] != null &&
-        result['quoted_status_result']['result'] != null &&
-        result['quoted_status_result']['result']?['__typename'] != 'TweetWithVisibilityResults') {
-      quotedStatus = TweetWithCard.fromGraphqlJson(result['quoted_status_result']['result']!);
-    } else if (result['quoted_status_result'] != null) {
-      // sometimes the quoted tweet is unavailable; this way we have a placeholder showing there was a tweet here
-      quotedStatus = TweetWithCard.tombstone({});
+    if (result['quoted_status_result'] != null && result['quoted_status_result']['result'] != null){
+      // tweets that limit who can reply (TweetWithVisibilityResults) are wrapped in another layer
+      var quotedTweetResult =
+        result['quoted_status_result']['result']?['__typename'] == 'TweetWithVisibilityResults'
+        ? result['quoted_status_result']['result']['tweet']
+        : result['quoted_status_result']['result'];
+      quotedStatus = TweetWithCard.fromGraphqlJson(quotedTweetResult);
     }
 
     var resCore = result['core']?['user_results']?['result'];

--- a/lib/tweet/tweet.dart
+++ b/lib/tweet/tweet.dart
@@ -29,6 +29,7 @@ class TweetTile extends StatefulWidget {
   final TweetWithCard tweet;
   final bool isPinned;
   final bool isThread;
+  final bool isQuotedTweet;
 
   final bool tweetOpened;
   final bool addSeparator;
@@ -41,7 +42,8 @@ class TweetTile extends StatefulWidget {
       this.isPinned = false,
       this.isThread = false,
       this.tweetOpened = false,
-      this.addSeparator = true});
+      this.addSeparator = true,
+      this.isQuotedTweet = false});
 
   @override
   TweetTileState createState() => TweetTileState();
@@ -55,6 +57,7 @@ class TweetTileState extends State<TweetTile> with SingleTickerProviderStateMixi
   late final TweetWithCard tweet;
   late final bool isPinned;
   late final bool isThread;
+  late final bool isQuotedTweet;
   late final bool addSeparator;
 
   TranslationStatus _translationStatus = TranslationStatus.original;
@@ -74,6 +77,7 @@ class TweetTileState extends State<TweetTile> with SingleTickerProviderStateMixi
     tweet = widget.tweet;
     isPinned = widget.isPinned;
     isThread = widget.isThread;
+    isQuotedTweet = widget.isQuotedTweet;
     addSeparator = widget.addSeparator;
   }
 
@@ -184,6 +188,18 @@ class TweetTileState extends State<TweetTile> with SingleTickerProviderStateMixi
     return newHsl.toColor();
   }
 
+  Widget _buildErrorTweet(String text) {
+    // create the layout of tombstones (deleted tweets) and other possible errors that we want to display as a tweet
+    return SizedBox(
+      width: double.infinity,
+      child: Card(
+        child: Container(
+            padding: const EdgeInsets.all(16),
+            child: Text(text, style: const TextStyle(fontStyle: FontStyle.italic))),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final prefs = PrefService.of(context, listen: false);
@@ -203,14 +219,7 @@ class TweetTileState extends State<TweetTile> with SingleTickerProviderStateMixi
     var theme = Theme.of(context);
 
     if (tweet.isTombstone ?? false) {
-      return SizedBox(
-        width: double.infinity,
-        child: Card(
-          child: Container(
-              padding: const EdgeInsets.all(16),
-              child: Text(tweet.text!, style: const TextStyle(fontStyle: FontStyle.italic))),
-        ),
-      );
+      return _buildErrorTweet(tweet.text!);
     }
 
     Widget media = Container();
@@ -272,21 +281,38 @@ class TweetTileState extends State<TweetTile> with SingleTickerProviderStateMixi
 
     var quotedTweet = Container();
 
-    if (tweet.isQuoteStatus ?? false) {
+    // don't display a nested quoted tweet if we are already building a quoted tweet
+    if (!isQuotedTweet && (tweet.isQuoteStatus ?? false)) {
+      Widget quotedContent;
       if (tweet.quotedStatusWithCard != null) {
-        quotedTweet = Container(
-          decoration: BoxDecoration(
-              border: Border.all(color: theme.colorScheme.surfaceBright.withAlpha(180)),
-              borderRadius: BorderRadius.circular(8)),
-          margin: const EdgeInsets.all(8),
-          child: TweetTile(
+        // if we got the full tweet in the reply
+        quotedContent = TweetTile(
             clickable: true,
             tweet: tweet.quotedStatusWithCard!,
             currentUsername: currentUsername,
             addSeparator: false,
-          ),
+            isQuotedTweet: true,
+          );
+      } else if (tweet.quotedStatusIdStr != null) {
+        // If twitter did not gave us the full tweet for some reason, we show a clickable tile to the tweet
+        // There always seem to be an actual link to the quoted tweet that we can display (showing username + id)
+        String? msg = tweet.quotedStatusPermalink?.display ?? 'View quoted tweet'; // Just in case, add a default String
+        quotedContent = GestureDetector(
+            onTap: () => Navigator.pushNamed(context, routeStatus,
+                arguments: StatusScreenArguments(id: tweet.quotedStatusIdStr!, username: null)),
+            child: _buildErrorTweet(msg)
         );
+      } else {
+        // If we have a quote tweet we should at least have quotedStatusIdStr, but just in case twitter is being weird
+        quotedContent = _buildErrorTweet('Could not retrieve quoted tweet');
       }
+      quotedTweet = Container(
+        decoration: BoxDecoration(
+        border: Border.all(color: theme.colorScheme.surfaceBright.withAlpha(180)),
+        borderRadius: BorderRadius.circular(8)),
+        margin: const EdgeInsets.all(8),
+        child: quotedContent,
+      );
     }
 
     // Only create the tweet content if the tweet contains text

--- a/lib/tweet/tweet.dart
+++ b/lib/tweet/tweet.dart
@@ -92,7 +92,7 @@ class TweetTileState extends State<TweetTile> with SingleTickerProviderStateMixi
     var actualTweet = tweet.retweetedStatusWithCard ?? tweet;
     // get the longest tweet between legacy (still used most of the time) and noteText (mostly ny premium users?)
     var tweetTextFinal = actualTweet.noteText ?? actualTweet.fullText ?? actualTweet.text!;
-    var entitiesFinal = actualTweet.noteEntities ?? actualTweet.entities!;
+    var entitiesFinal = actualTweet.noteEntities ?? actualTweet.entities;
 
     List<RichTextPart> tweetParts = buildRichText(context, tweetTextFinal, entitiesFinal);
     setState(() {
@@ -195,7 +195,8 @@ class TweetTileState extends State<TweetTile> with SingleTickerProviderStateMixi
     TweetWithCard tweet = this.tweet.retweetedStatusWithCard == null ? this.tweet : this.tweet.retweetedStatusWithCard!;
 
     // If the user is on a profile, all the shown tweets are from that profile, so it makes no sense to hide it
-    final isTweetOnSameProfile = currentUsername != null && currentUsername == tweet.user!.screenName;
+    final isTweetOnSameProfile =
+        currentUsername != null && tweet.user != null && currentUsername == tweet.user!.screenName;
     final hideAuthorInformation = !isTweetOnSameProfile && prefs.get(optionNonConfirmationBiasMode);
 
     var numberFormat = NumberFormat.compact();


### PR DESCRIPTION
Fix a bug with a missing null check that was sometimes displaying stack traces in tweets and replies
Improve handling of quote tweets that sometimes were omitted in certain conditions and add a placeholder for when a quoted tweet is present but not returned by the API for some reason.