### PR TITLE
Added support for articles. Supported article content: text, images, …

### DIFF
--- a/lib/article/article.dart
+++ b/lib/article/article.dart
@@ -1,0 +1,333 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:quax/article/article_parser.dart';
+import 'package:quax/constants.dart';
+import 'package:quax/profile/profile.dart';
+import 'package:quax/utils/urls.dart';
+
+class Article {
+  final String title;
+  final String previewText;
+  final List<ArticleTextBlock> textParts;
+  Map<int, EntityValue> entities;
+  ImageEntity? coverMedia;
+
+  Article(this.title, this.previewText, this.textParts, this.entities, this.coverMedia);
+
+  Map<String, dynamic> toJson() {
+    return {
+      'title': title,
+      'previewText': previewText,
+      'coverMediaUrl': coverMedia?.imageUrl,
+    };
+  }
+
+  factory Article.fromJson(Map<String, dynamic> e) {
+    final coverMediaUrl = e['coverMediaUrl'] as String?;
+    return Article(
+      e['title'] as String? ?? '',
+      e['previewText'] as String? ?? '',
+      [],
+      {},
+      coverMediaUrl == null ? null : ImageEntity(imageUrl: coverMediaUrl),
+    );
+  }
+
+  factory Article.fromGraphqlJson(Map<String, dynamic> articleResult, String tweetIdStr, String user) {
+    final title = articleResult["title"] ?? "";
+    final previewText = articleResult["preview_text"] ?? "";
+
+    Map<int, EntityValue> entities = {};
+    if (articleResult["content_state"]?["entityMap"] != null && articleResult["media_entities"] != null) {
+      entities = EntityMapParser.parse(
+        articleResult["content_state"]["entityMap"] is List<dynamic> ? articleResult["content_state"]["entityMap"] : [],
+        articleResult["media_entities"],
+        tweetIdStr,
+        user,
+      );
+    }
+
+    final blocks = articleResult["content_state"]?["blocks"] ?? [];
+    final coverMediaJson = articleResult["cover_media"]?["media_info"]?["original_img_url"];
+
+    final coverMedia = coverMediaJson == null ? null : ImageEntity(imageUrl: coverMediaJson);
+    return Article(title, previewText, List.from(blocks.map((e) => blockToRichText(e))), entities, coverMedia);
+  }
+}
+
+class ArticleWidget extends StatelessWidget {
+  final Article article;
+  final EdgeInsetsGeometry padding;
+  final TextStyle? titleStyle;
+  final TextStyle? previewStyle;
+  final TextStyle? contentStyle;
+  final bool expand;
+  final VoidCallback? onTap;
+  final Widget? bottomBar;
+
+  const ArticleWidget({
+    super.key,
+    required this.article,
+    this.padding = const EdgeInsets.all(16),
+    this.titleStyle,
+    this.previewStyle,
+    this.contentStyle,
+    required this.expand,
+    required this.onTap,
+    this.bottomBar,
+  });
+
+  TextSpan _tapSpan(
+    BuildContext context, {
+    required String? text,
+    required TextStyle? style,
+    required VoidCallback onTap,
+    bool underline = true,
+  }) {
+    return TextSpan(
+      text: text,
+      style: style?.copyWith(
+        color: Theme.of(context).colorScheme.primary,
+        decoration: underline ? TextDecoration.underline : TextDecoration.none,
+        decorationColor: underline ? Theme.of(context).colorScheme.primary : null,
+      ),
+      recognizer: TapGestureRecognizer()..onTap = onTap,
+    );
+  }
+
+  TextSpan _linkSpan(BuildContext context, {required String? text, required TextStyle? style, required String url}) {
+    if (!url.startsWith('https://') && !url.startsWith('http://')) {
+      url = 'https://$url';
+    }
+    return _tapSpan(context, text: text, style: style, onTap: () => openUri(url));
+  }
+
+  TextSpan _mentionSpan(
+    BuildContext context, {
+    required String? text,
+    required TextStyle? style,
+    required String screenName,
+  }) {
+    return _tapSpan(
+      context,
+      text: text,
+      style: style,
+      underline: false,
+      onTap: () {
+        Navigator.pushNamed(context, routeProfile, arguments: ProfileScreenArguments(null, screenName, null));
+      },
+    );
+  }
+
+  InlineSpan entityPlaceHolderReplace(BuildContext context, EntityPlaceHolderTextSpan placeHolder) {
+    final key = placeHolder.entityKey;
+    if (!article.entities.containsKey(key)) {
+      return placeHolder;
+    }
+
+    final entity = article.entities[key];
+    if (entity is LinkEntity) {
+      return _linkSpan(context, text: placeHolder.text, style: placeHolder.style, url: entity.url);
+    }
+    return placeHolder;
+  }
+
+  InlineSpan replacePlaceHolders(BuildContext context, InlineSpan span) {
+    if (span is TextSpan) {
+      if (span is EntityPlaceHolderTextSpan) {
+        return entityPlaceHolderReplace(context, span);
+      }
+
+      if (span is DataUrlTextSpan) {
+        return _linkSpan(context, text: span.text, style: span.style, url: span.url);
+      }
+
+      if (span is DataMentionTextSpan) {
+        return _mentionSpan(context, text: span.text, style: span.style, screenName: span.screenName);
+      }
+
+      if (span.children != null && span.children!.isNotEmpty) {
+        final newChildren = span.children!.map((child) => replacePlaceHolders(context, child)).toList();
+        return TextSpan(text: span.text, style: span.style, children: newChildren);
+      }
+
+      return span;
+    }
+
+    return span;
+  }
+
+  List<Widget> _buildParagraphSpans(BuildContext context) {
+    final result = <Widget>[];
+
+    int orderedListItemIndex = 0;
+    for (int i = 0; i < article.textParts.length; i++) {
+      EdgeInsets padding;
+      void addListItem(EdgeInsets padding, Widget prefix, InlineSpan textSpan) {
+        result.add(
+          Padding(
+            padding: padding,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                prefix,
+                Expanded(child: SelectableText.rich(TextSpan(children: [textSpan]))),
+              ],
+            ),
+          ),
+        );
+      }
+
+      final spans = replacePlaceHolders(context, article.textParts[i].inlineSpan);
+
+      switch (article.textParts[i].type) {
+        case ArticleTextBlockType.unorderedListItem:
+          padding = const EdgeInsets.fromLTRB(6.0, 4.0, 0.0, 4.0);
+          addListItem(padding, const Text("• "), spans);
+          orderedListItemIndex = 0;
+          break;
+        case ArticleTextBlockType.orderedListItem:
+          padding = const EdgeInsets.fromLTRB(6.0, 4.0, 0.0, 4.0);
+          addListItem(padding, Text("${orderedListItemIndex + 1}. "), spans);
+          orderedListItemIndex++;
+          break;
+        case ArticleTextBlockType.headerTwo:
+          padding = const EdgeInsets.symmetric(vertical: 16.0);
+          orderedListItemIndex = 0;
+          break;
+        case ArticleTextBlockType.blockquote:
+          final colorScheme = Theme.of(context).colorScheme;
+          padding = const EdgeInsets.symmetric(vertical: 8.0);
+          result.add(
+            Padding(
+              padding: padding,
+              child: Container(
+                padding: const EdgeInsets.fromLTRB(12.0, 8.0, 8.0, 8.0),
+                decoration: BoxDecoration(
+                  border: Border(
+                    left: BorderSide(
+                      color: Color.alphaBlend(
+                        colorScheme.onSurface.withValues(alpha: 0.08),
+                        colorScheme.surfaceContainer,
+                      ),
+                      width: 4.0,
+                    ),
+                  ),
+                  color: Theme.of(context).colorScheme.surfaceContainer,
+                ),
+                child: SelectableText.rich(TextSpan(children: [spans])),
+              ),
+            ),
+          );
+          orderedListItemIndex = 0;
+          break;
+        case ArticleTextBlockType.unstyled:
+        default:
+          padding = const EdgeInsets.symmetric(vertical: 8.0);
+          orderedListItemIndex = 0;
+      }
+
+      if (article.textParts[i].type != ArticleTextBlockType.atomic &&
+          article.textParts[i].type != ArticleTextBlockType.unorderedListItem &&
+          article.textParts[i].type != ArticleTextBlockType.orderedListItem &&
+          article.textParts[i].type != ArticleTextBlockType.blockquote) {
+        result.add(
+          Padding(
+            padding: padding,
+            child: SelectableText.rich(TextSpan(children: [spans])),
+          ),
+        );
+      }
+
+      for (final entityRange in article.textParts[i].entityRanges) {
+        final w = article.entities[entityRange["key"]];
+        if (w == null || w is LinkEntity) continue;
+        result.add(Padding(padding: EdgeInsets.symmetric(vertical: 4.0), child: w.toWidget(context)));
+      }
+    }
+
+    return result;
+  }
+
+  Widget _buildCollapsed(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Container(
+          decoration: BoxDecoration(
+            border: Border.all(color: colorScheme.outlineVariant.withValues(alpha: 0.6)),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          clipBehavior: Clip.hardEdge,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (article.coverMedia != null) article.coverMedia!.toWidget(context),
+              Padding(
+                padding: const EdgeInsets.all(12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      article.title,
+                      style: titleStyle ?? theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    if (article.previewText.isNotEmpty) ...[
+                      const SizedBox(height: 4),
+                      Text(
+                        article.previewText,
+                        style: previewStyle ?? theme.textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant),
+                        maxLines: 3,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                    const SizedBox(height: 8),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    if (!expand) return _buildCollapsed(context);
+
+    return Padding(
+      padding: padding,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (article.coverMedia != null) ...[
+            Padding(padding: const EdgeInsets.only(bottom: 16.0), child: article.coverMedia!.toWidget(context)),
+          ],
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8.0),
+            child: Text(
+              article.title,
+              style: titleStyle ?? theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+            ),
+          ),
+          if (bottomBar != null) ...[
+            bottomBar!,
+            Divider(height: 1, color: theme.colorScheme.surfaceBright.withAlpha(150)),
+            const SizedBox(height: 16),
+          ],
+          ..._buildParagraphSpans(context),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/article/article_block_parser.dart
+++ b/lib/article/article_block_parser.dart
@@ -1,0 +1,254 @@
+import 'package:flutter/material.dart';
+
+import 'package:quax/article/article_text_block.dart';
+
+ArticleTextBlock blockToRichText(Map<String, dynamic> block, {TextStyle? baseStyle}) {
+  final String text = (block['text'] ?? '') as String;
+  final String type = (block['type'] ?? 'unstyled') as String;
+  final List<dynamic> inlineStyleRanges = (block['inlineStyleRanges'] ?? []) as List<dynamic>;
+  final List<dynamic> entityRanges = (block['entityRanges'] ?? []) as List<dynamic>;
+  final Map<String, dynamic>? data = block['data'] as Map<String, dynamic>?;
+  final List<dynamic> dataUrls = (data?['urls'] ?? []) as List<dynamic>;
+  final List<dynamic> dataMentions = (data?['mentions'] ?? []) as List<dynamic>;
+
+  final TextStyle defaultStyle = baseStyle ?? const TextStyle();
+  final TextStyle blockStyle = _styleForBlockType(type, defaultStyle);
+
+  final List<TextSpan> children = _buildStyledTextSpans(text, inlineStyleRanges, entityRanges, dataUrls, dataMentions, blockStyle);
+
+  switch (type) {
+    case 'atomic':
+      return ArticleTextBlock(TextSpan(), entityRanges, ArticleTextBlockType.atomic);
+    case 'unordered-list-item':
+      return ArticleTextBlock(
+        TextSpan(style: blockStyle, children: children),
+        entityRanges,
+        ArticleTextBlockType.unorderedListItem,
+      );
+    case 'ordered-list-item':
+      return ArticleTextBlock(
+        TextSpan(style: blockStyle, children: children),
+        entityRanges,
+        ArticleTextBlockType.orderedListItem,
+      );
+    case 'header-two':
+      return ArticleTextBlock(TextSpan(style: blockStyle, children: children), entityRanges, ArticleTextBlockType.headerTwo);
+    case 'blockquote':
+      return ArticleTextBlock(TextSpan(style: blockStyle, children: children), entityRanges, ArticleTextBlockType.blockquote);
+    case 'unstyled':
+    default:
+      return ArticleTextBlock(TextSpan(style: blockStyle, children: children), entityRanges, ArticleTextBlockType.unstyled);
+
+  }
+}
+
+TextStyle _styleForBlockType(String type, TextStyle baseStyle) {
+  switch (type) {
+    case 'header-two':
+      return baseStyle.copyWith(fontSize: 22, fontWeight: FontWeight.w700, height: 1.4);
+    case 'unordered-list-item':
+    case 'ordered-list-item':
+      return baseStyle.copyWith(fontSize: 14, height: 1.5);
+    case 'unstyled':
+    default:
+      return baseStyle.copyWith(fontSize: 14, height: 1.5);
+  }
+}
+
+List<TextSpan> _buildStyledTextSpans(String text, List<dynamic> inlineStyleRanges, List<dynamic> entityRanges, List<dynamic> dataUrls, List<dynamic> dataMentions, TextStyle baseStyle) {
+  if (text.isEmpty) return [TextSpan(text: '', style: baseStyle)];
+
+  final markers = _parseStyleMarkers(text, inlineStyleRanges);
+  final entityMarkers = _parseEntityMarkers(text, entityRanges);
+  final urlMarkers = _parseUrlMarkers(text, dataUrls);
+  final mentionMarkers = _parseMentionMarkers(text, dataMentions);
+
+  if (markers.isEmpty && entityMarkers.isEmpty && urlMarkers.isEmpty && mentionMarkers.isEmpty) return [TextSpan(text: text, style: baseStyle)];
+
+  final List<TextSpan> spans = [];
+  int current = 0;
+
+  while (current < text.length) {
+    final activeStyles = markers.where((m) => current >= m.start && current < m.end).toList();
+    final activeEntities = entityMarkers.where((m) => current >= m.start && current < m.end).toList();
+    final activeUrls = urlMarkers.where((m) => current >= m.start && current < m.end).toList();
+    final activeMentions = mentionMarkers.where((m) => current >= m.start && current < m.end).toList();
+    final nextBreak = _findNextBreak(current, text.length, markers, entityMarkers, urlMarkers, mentionMarkers);
+
+    final String segment = text.substring(current, nextBreak);
+    TextStyle segmentStyle = baseStyle;
+    for (final marker in activeStyles) {
+      segmentStyle = _applyInlineStyle(segmentStyle, marker.style);
+    }
+
+    spans.add(_buildSegmentSpan(segment, segmentStyle, activeEntities, activeUrls, activeMentions));
+    current = nextBreak;
+  }
+
+  return spans;
+}
+
+// Converts a Unicode code point offset to a Dart UTF-16 code unit offset.
+// Necessary because the API provides code point offsets, but Dart's String
+// is UTF-16 where emojis (and other non-BMP characters) occupy 2 code units.
+int _cpToUtf16(String text, int cpOffset) {
+  int utf16 = 0;
+  int cp = 0;
+  for (final rune in text.runes) {
+    if (cp == cpOffset) break;
+    utf16 += rune > 0xFFFF ? 2 : 1;
+    cp++;
+  }
+  return utf16;
+}
+
+List<_StyleMarker> _parseStyleMarkers(String text, List<dynamic> inlineStyleRanges) {
+  final markers = <_StyleMarker>[];
+  for (final dynamic range in inlineStyleRanges) {
+    if (range is! Map<String, dynamic>) continue;
+    final int cpStart = (range['offset'] ?? 0) as int;
+    final int cpLength = (range['length'] ?? 0) as int;
+    final String styleName = (range['style'] ?? '') as String;
+    final int start = _cpToUtf16(text, cpStart);
+    final int end = _cpToUtf16(text, cpStart + cpLength);
+    if (start < 0 || end > text.length || start >= end) continue;
+    markers.add(_StyleMarker(start: start, end: end, style: styleName));
+  }
+  return markers;
+}
+
+List<_EntityMarker> _parseEntityMarkers(String text, List<dynamic> entityRanges) {
+  final entityMarkers = <_EntityMarker>[];
+  for (final dynamic range in entityRanges) {
+    if (range is! Map<String, dynamic>) continue;
+    final int cpStart = (range['offset'] ?? 0) as int;
+    final int cpLength = (range['length'] ?? 0) as int;
+    final dynamic key = range['key'];
+    final int start = _cpToUtf16(text, cpStart);
+    final int end = _cpToUtf16(text, cpStart + cpLength);
+    if (start < 0 || end > text.length || start >= end) continue;
+    entityMarkers.add(_EntityMarker(start: start, end: end, key: key));
+  }
+  return entityMarkers;
+}
+
+List<_UrlMarker> _parseUrlMarkers(String text, List<dynamic> dataUrls) {
+  final urlMarkers = <_UrlMarker>[];
+  for (final dynamic entry in dataUrls) {
+    if (entry is! Map<String, dynamic>) continue;
+    final int cpStart = (entry['fromIndex'] ?? 0) as int;
+    final int cpEnd = (entry['toIndex'] ?? 0) as int;
+    final String urlText = (entry['text'] ?? '') as String;
+    final int start = _cpToUtf16(text, cpStart);
+    final int end = _cpToUtf16(text, cpEnd);
+    if (start < 0 || end > text.length || start >= end) continue;
+    urlMarkers.add(_UrlMarker(start: start, end: end, url: urlText));
+  }
+  return urlMarkers;
+}
+
+int _findNextBreak(int current, int textLength, List<_StyleMarker> markers, List<_EntityMarker> entityMarkers, [List<_UrlMarker> urlMarkers = const [], List<_MentionMarker> mentionMarkers = const []]) {
+  int nextBreak = textLength;
+  for (final marker in markers) {
+    if (marker.start > current && marker.start < nextBreak) nextBreak = marker.start;
+    if (marker.end > current && marker.end < nextBreak) nextBreak = marker.end;
+  }
+  for (final marker in entityMarkers) {
+    if (marker.start > current && marker.start < nextBreak) nextBreak = marker.start;
+    if (marker.end > current && marker.end < nextBreak) nextBreak = marker.end;
+  }
+  for (final marker in urlMarkers) {
+    if (marker.start > current && marker.start < nextBreak) nextBreak = marker.start;
+    if (marker.end > current && marker.end < nextBreak) nextBreak = marker.end;
+  }
+  for (final marker in mentionMarkers) {
+    if (marker.start > current && marker.start < nextBreak) nextBreak = marker.start;
+    if (marker.end > current && marker.end < nextBreak) nextBreak = marker.end;
+  }
+  return nextBreak;
+}
+
+TextSpan _buildSegmentSpan(String segment, TextStyle style, List<_EntityMarker> activeEntities, [List<_UrlMarker> activeUrls = const [], List<_MentionMarker> activeMentions = const []]) {
+  if (activeEntities.isNotEmpty) {
+    return EntityPlaceHolderTextSpan(
+      entityText: segment,
+      entityKey: activeEntities.first.key,
+      style: style,
+    );
+  }
+  if (activeUrls.isNotEmpty) {
+    return DataUrlTextSpan(
+      text: segment,
+      url: activeUrls.first.url,
+      style: style,
+    );
+  }
+  if (activeMentions.isNotEmpty) {
+    return DataMentionTextSpan(
+      text: segment,
+      screenName: activeMentions.first.screenName,
+      style: style,
+    );
+  }
+  return TextSpan(text: segment, style: style);
+}
+
+TextStyle _applyInlineStyle(TextStyle style, String styleName) {
+  switch (styleName.toLowerCase()) {
+    case 'bold':
+      return style.copyWith(fontWeight: FontWeight.bold);
+    case 'italic':
+      return style.copyWith(fontStyle: FontStyle.italic);
+    case 'underline':
+      return style.copyWith(decoration: TextDecoration.underline);
+    default:
+      return style;
+  }
+}
+
+class _StyleMarker {
+  final int start;
+  final int end;
+  final String style;
+
+  _StyleMarker({required this.start, required this.end, required this.style});
+}
+
+class _EntityMarker {
+  final int start;
+  final int end;
+  final dynamic key;
+
+  _EntityMarker({required this.start, required this.end, required this.key});
+}
+
+class _UrlMarker {
+  final int start;
+  final int end;
+  final String url;
+
+  _UrlMarker({required this.start, required this.end, required this.url});
+}
+
+List<_MentionMarker> _parseMentionMarkers(String text, List<dynamic> dataMentions) {
+  final mentionMarkers = <_MentionMarker>[];
+  for (final dynamic entry in dataMentions) {
+    if (entry is! Map<String, dynamic>) continue;
+    final int cpStart = (entry['fromIndex'] ?? 0) as int;
+    final int cpEnd = (entry['toIndex'] ?? 0) as int;
+    final String screenName = (entry['text'] ?? '') as String;
+    final int start = _cpToUtf16(text, cpStart);
+    final int end = _cpToUtf16(text, cpEnd);
+    if (start < 0 || end > text.length || start >= end) continue;
+    mentionMarkers.add(_MentionMarker(start: start, end: end, screenName: screenName));
+  }
+  return mentionMarkers;
+}
+
+class _MentionMarker {
+  final int start;
+  final int end;
+  final String screenName;
+
+  _MentionMarker({required this.start, required this.end, required this.screenName});
+}

--- a/lib/article/article_entities.dart
+++ b/lib/article/article_entities.dart
@@ -1,0 +1,1 @@
+export 'package:quax/article/entities/entity_value.dart';

--- a/lib/article/article_parser.dart
+++ b/lib/article/article_parser.dart
@@ -1,0 +1,4 @@
+export 'package:quax/article/article_text_block.dart';
+export 'package:quax/article/article_block_parser.dart';
+export 'package:quax/article/article_entities.dart';
+export 'package:quax/article/entity_map_parser.dart';

--- a/lib/article/article_text_block.dart
+++ b/lib/article/article_text_block.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+enum ArticleTextBlockType {
+  unorderedListItem,
+  orderedListItem,
+  headerTwo,
+  unstyled,
+  atomic,
+  blockquote
+}
+
+class ArticleTextBlock {
+  InlineSpan inlineSpan;
+  List<dynamic> entityRanges;
+  ArticleTextBlockType type;
+
+  ArticleTextBlock(this.inlineSpan, this.entityRanges, this.type);
+}
+
+class EntityPlaceHolderTextSpan extends TextSpan {
+  final String entityText;
+  final int entityKey;
+
+  const EntityPlaceHolderTextSpan({
+    required this.entityText,
+    required this.entityKey,
+    super.style,
+  }) : super(text: entityText);
+}
+
+class DataUrlTextSpan extends TextSpan {
+  final String url;
+
+  const DataUrlTextSpan({
+    required String text,
+    required this.url,
+    super.style,
+  }) : super(text: text);
+}
+
+class DataMentionTextSpan extends TextSpan {
+  final String screenName;
+
+  const DataMentionTextSpan({
+    required String text,
+    required this.screenName,
+    super.style,
+  }) : super(text: text);
+}

--- a/lib/article/entities/divider_entity.dart
+++ b/lib/article/entities/divider_entity.dart
@@ -1,0 +1,14 @@
+part of 'entity_value.dart';
+
+class DividerEntity extends EntityValue {
+  @override
+  Widget toWidget(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: Divider(
+        thickness: 1.5,
+        color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.2),
+      ),
+    );
+  }
+}

--- a/lib/article/entities/entity_value.dart
+++ b/lib/article/entities/entity_value.dart
@@ -1,0 +1,18 @@
+import 'package:extended_image/extended_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:quax/tweet/_media.dart';
+import 'package:quax/tweet/_video.dart';
+
+part 'markdown_entity.dart';
+part 'image_entity.dart';
+part 'video_entity.dart';
+part 'link_entity.dart';
+part 'divider_entity.dart';
+
+sealed class EntityValue {
+  const EntityValue();
+
+  Widget toWidget(BuildContext context);
+}

--- a/lib/article/entities/image_entity.dart
+++ b/lib/article/entities/image_entity.dart
@@ -1,0 +1,27 @@
+part of 'entity_value.dart';
+
+class ImageEntity extends EntityValue {
+  final String imageUrl;
+
+  const ImageEntity({required this.imageUrl});
+
+  @override
+  Widget toWidget(BuildContext context) {
+    return GestureDetector(
+      child: ExtendedImage.network(imageUrl, fit: BoxFit.fitWidth),
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => TweetMediaView(
+              initialIndex: 0,
+              media: [createMediaFromUrl(imageUrl, null)],
+              username: "Unknown",
+              tweetMedia: false,
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/article/entities/link_entity.dart
+++ b/lib/article/entities/link_entity.dart
@@ -1,0 +1,15 @@
+part of 'entity_value.dart';
+
+class LinkEntity extends EntityValue {
+  final String url;
+
+  const LinkEntity({required this.url});
+
+  @override
+  Widget toWidget(BuildContext context) {
+    return Text(
+      url,
+      style: const TextStyle(color: Colors.blue, decoration: TextDecoration.underline),
+    );
+  }
+}

--- a/lib/article/entities/markdown_entity.dart
+++ b/lib/article/entities/markdown_entity.dart
@@ -1,0 +1,79 @@
+part of 'entity_value.dart';
+
+class MarkdownEntity extends EntityValue {
+  final String language;
+  final String code;
+
+  MarkdownEntity._({required this.language, required this.code});
+
+  factory MarkdownEntity({required String markdown}) {
+    final (language, code) = _parse(markdown);
+    return MarkdownEntity._(language: language, code: code);
+  }
+
+  static (String, String) _parse(String markdown) {
+    final trimmed = markdown.trim();
+    final firstNewline = trimmed.indexOf('\n');
+    if (!trimmed.startsWith('```') || firstNewline == -1) {
+      return ('', trimmed);
+    }
+    final language = trimmed.substring(3, firstNewline).trim();
+    final withoutOpen = trimmed.substring(firstNewline + 1);
+    final code = withoutOpen.endsWith('```')
+        ? withoutOpen.substring(0, withoutOpen.length - 3).trimRight()
+        : withoutOpen;
+    return (language, code);
+  }
+
+  @override
+  Widget toWidget(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(8.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+            Container(
+              color: Color.alphaBlend(colorScheme.onSurface.withValues(alpha: 0.08), colorScheme.surfaceContainer),
+              padding: const EdgeInsets.only(left: 12.0),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      language,
+                      style: const TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  Tooltip(
+                    message: 'Copy',
+                    child: InkWell(
+                      onTap: () => Clipboard.setData(ClipboardData(text: code)),
+                      child: const Padding(
+                        padding: EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0),
+                        child: Icon(Icons.copy, size: 16),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          Container(
+            color: colorScheme.surfaceContainer,
+            padding: const EdgeInsets.all(16.0),
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: SelectableText(
+                code,
+                style: const TextStyle(fontFamily: 'monospace'),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/article/entities/video_entity.dart
+++ b/lib/article/entities/video_entity.dart
@@ -1,0 +1,12 @@
+part of 'entity_value.dart';
+
+class VideoEntity extends EntityValue {
+  final TweetVideoMetadata metadata;
+
+  const VideoEntity({required this.metadata});
+
+  @override
+  Widget toWidget(BuildContext context) {
+    return TweetVideo(metadata: metadata, loop: false, username: "Unknown");
+  }
+}

--- a/lib/article/entity_map_parser.dart
+++ b/lib/article/entity_map_parser.dart
@@ -1,0 +1,103 @@
+import 'dart:convert';
+
+import 'package:dart_twitter_api/twitter_api.dart';
+
+import 'package:quax/article/article_entities.dart';
+import 'package:quax/tweet/_video.dart';
+import 'package:quax/utils/iterables.dart';
+
+class EntityMapParser {
+  static Map<int, EntityValue> parse(dynamic json, List<dynamic> mediaEntitiesJson, String tweetIdStr, String user) {
+    final List<dynamic> entityList;
+
+    if (json is String) {
+      final decoded = jsonDecode(json);
+      if (decoded is Map<String, dynamic>) {
+        entityList = (decoded['entityMap'] as List<dynamic>? ?? <dynamic>[]);
+      } else if (decoded is List<dynamic>) {
+        entityList = decoded;
+      } else {
+        return <int, EntityValue>{};
+      }
+    } else if (json is Map<String, dynamic>) {
+      entityList = (json['entityMap'] as List<dynamic>? ?? <dynamic>[]);
+    } else if (json is List<dynamic>) {
+      entityList = json;
+    } else {
+      return <int, EntityValue>{};
+    }
+
+    final result = <int, EntityValue>{};
+
+    for (final item in entityList) {
+      if (item is! Map<String, dynamic>) continue;
+
+      final keyRaw = item['key'];
+      final key = int.tryParse('$keyRaw');
+      if (key == null) continue;
+
+      final value = item['value'];
+      if (value is! Map<String, dynamic>) continue;
+
+      final type = (value['type'] ?? '').toString();
+      final data = value['data'];
+
+      if (data is! Map<String, dynamic>) continue;
+
+      switch (type) {
+        case 'MARKDOWN':
+          final markdown = data['markdown']?.toString();
+          if (markdown != null) {
+            result[key] = MarkdownEntity(markdown: markdown);
+          }
+          break;
+
+        case 'MEDIA':
+          final mediaItems = data['mediaItems'];
+          if (mediaItems is List && mediaItems.isNotEmpty) {
+            final firstItem = mediaItems.first;
+            if (firstItem is Map<String, dynamic>) {
+              final mediaId = firstItem['mediaId']?.toString();
+              if (mediaId != null && mediaId.isNotEmpty) {
+                final res = mediaEntitiesJson.firstWhereOrNull((e) => e["media_id"] == mediaId);
+                if (res["media_info"]?["__typename"] == "ApiImage") {
+                  final url = res["media_info"]?["original_img_url"] ?? "";
+                  result[key] = ImageEntity(imageUrl: url);
+                } else if (res["media_info"]?["__typename"] == "ApiVideo") {
+                  final variantsJson = res["media_info"]?["variants"];
+                  List<Variant> variants = [];
+                  if (variantsJson is List<dynamic>) {
+                    variants = List.from(variantsJson.map((e) =>
+                      Variant()
+                        ..bitrate = e['bit_rate'] as int?
+                        ..contentType = e['content_type'] as String?
+                        ..url = e['url'] as String?));
+                  }
+                  result[key] = VideoEntity(
+                    metadata: TweetVideoMetadata(
+                      (res["media_info"]?["aspect_ratio"]?["numerator"] ?? 1.0) / (res["media_info"]?["aspect_ratio"]?["denominator"] ?? 1.0),
+                      res["media_info"]?["preview_image"]?["original_img_url"],
+                      TweetVideoMetadata.streamUrlsBuilderFromVariants(variants),
+                    ),
+                  );
+                }
+              }
+            }
+          }
+          break;
+
+        case 'LINK':
+          final url = data['url']?.toString();
+          if (url != null) {
+            result[key] = LinkEntity(url: url);
+          }
+          break;
+
+        case 'DIVIDER':
+          result[key] = DividerEntity();
+      }
+    }
+
+    return result;
+  }
+}

--- a/lib/client/client.dart
+++ b/lib/client/client.dart
@@ -10,6 +10,7 @@ import 'package:quax/client/client_unauthenticated.dart';
 import 'package:quax/client/headers.dart';
 import 'package:quax/generated/l10n.dart';
 import 'package:quax/profile/profile_model.dart';
+import 'package:quax/article/article.dart';
 import 'package:quax/user.dart';
 import 'package:quax/utils/cache.dart';
 import 'package:quax/utils/iterables.dart';
@@ -107,7 +108,7 @@ class Twitter {
     'spelling_corrections': '1',
     'include_ext_edit_control': 'true',
     'ext':
-        'mediaStats,highlightedLabel,hasNftAvatar,voiceInfo,enrichments,superFollowMetadata,unmentionInfo,editControl,collab_control,vibe,'
+        'mediaStats,highlightedLabel,hasNftAvatar,voiceInfo,enrichments,superFollowMetadata,unmentionInfo,editControl,collab_control,vibe,',
   };
 
   static Map<String, bool> gqlFeatures = {
@@ -133,7 +134,7 @@ class Twitter {
     "tweetypie_unmention_optimization_enabled": false,
     "verified_phone_label_enabled": false,
     "vibe_api_enabled": false,
-    "view_counts_everywhere_api_enabled": true
+    "view_counts_everywhere_api_enabled": true,
   };
 
   static Future<Profile> getProfileById(String id) async {
@@ -142,13 +143,13 @@ class Twitter {
         'userId': id,
         'withHighlightedLabel': true,
         'withSafetyModeUserFields': true,
-        'withSuperFollowsUserFields': true
+        'withSuperFollowsUserFields': true,
       }),
       'features': jsonEncode({
         'responsive_web_graphql_timeline_navigation_enabled': true,
         'responsive_web_twitter_blue_verified_badge_is_enabled': true,
         'verified_phone_label_enabled': true,
-      })
+      }),
     });
 
     return _getProfile(uri);
@@ -172,8 +173,8 @@ class Twitter {
         "responsive_web_twitter_article_notes_tab_enabled": true,
         "creator_subscriptions_tweet_preview_api_enabled": true,
         "responsive_web_graphql_skip_user_profile_image_extensions_enabled": false,
-        "responsive_web_graphql_timeline_navigation_enabled": true
-      })
+        "responsive_web_graphql_timeline_navigation_enabled": true,
+      }),
     });
 
     return _getProfile(uri);
@@ -216,8 +217,11 @@ class Twitter {
       }
     }
 
-    var user = UserWithExtra.fromJson(
-        {...result['legacy'], 'id_str': result['rest_id'], 'ext_is_blue_verified': result['is_blue_verified']});
+    var user = UserWithExtra.fromJson({
+      ...result['legacy'],
+      'id_str': result['rest_id'],
+      'ext_is_blue_verified': result['is_blue_verified'],
+    });
     var pins = List<String>.from(result['legacy']['pinned_tweet_ids_str']);
 
     return Profile(user, pins);
@@ -225,8 +229,12 @@ class Twitter {
 
   static Future<PaginatedUsers> friendsList(String userId, int count) async {
     final uri = Uri.https('x.com', '/i/api/graphql/FEcMGoVOUjm0aU9BJrrGZA/Following', {
-      "variables": jsonEncode(
-          {"userId": userId, "count": count, "includePromotedContent": false, "withGrokTranslatedBio": false}),
+      "variables": jsonEncode({
+        "userId": userId,
+        "count": count,
+        "includePromotedContent": false,
+        "withGrokTranslatedBio": false,
+      }),
       "features": jsonEncode({
         "rweb_video_screen_enabled": false,
         "payments_enabled": false,
@@ -262,14 +270,15 @@ class Twitter {
         "responsive_web_grok_image_annotation_enabled": true,
         "responsive_web_grok_imagine_annotation_enabled": true,
         "responsive_web_grok_community_note_auto_translation_is_enabled": false,
-        "responsive_web_enhance_cards_enabled": false
-      })
+        "responsive_web_enhance_cards_enabled": false,
+      }),
     });
 
     return _twitterApi.client.get(uri).then((response) {
       var users = PaginatedUsers()..users = [];
-      dynamic instructions =
-          jsonDecode(response.body)?["data"]?["user"]?["result"]?["timeline"]?["timeline"]?["instructions"];
+      dynamic instructions = jsonDecode(
+        response.body,
+      )?["data"]?["user"]?["result"]?["timeline"]?["timeline"]?["instructions"];
       for (final instruction in instructions) {
         if (instruction["type"] != "TimelineAddEntries" || instruction["entries"] == null) continue;
         for (final entry in instruction["entries"]) {
@@ -289,20 +298,30 @@ class Twitter {
     });
   }
 
-  static Future<Follows> getProfileFollows(String screenName, String type,
-      {int? cursor, int? count = 200, String? id}) async {
+  static Future<Follows> getProfileFollows(
+    String screenName,
+    String type, {
+    int? cursor,
+    int? count = 200,
+    String? id,
+  }) async {
     if (type == "following" && id == null) {
       id = (await getProfileByScreenName(screenName)).user.idStr;
     }
     var response = type == 'following'
         ? (await friendsList(id!, count!))
-        : await _twitterApi.userService
-            .followersList(screenName: screenName, cursor: cursor, count: count, skipStatus: true);
+        : await _twitterApi.userService.followersList(
+            screenName: screenName,
+            cursor: cursor,
+            count: count,
+            skipStatus: true,
+          );
 
     return Follows(
-        cursorBottom: int.parse(response.nextCursorStr ?? '-1'),
-        cursorTop: int.parse(response.previousCursorStr ?? '-1'),
-        users: response.users?.map((e) => UserWithExtra.fromJson(e.toJson())).toList() ?? []);
+      cursorBottom: int.parse(response.nextCursorStr ?? '-1'),
+      cursorTop: int.parse(response.previousCursorStr ?? '-1'),
+      users: response.users?.map((e) => UserWithExtra.fromJson(e.toJson())).toList() ?? [],
+    );
   }
 
   static bool isNotPromoted(Map<String, dynamic> item) {
@@ -330,8 +349,9 @@ class Twitter {
         }
 
         if (result != null && result.containsKey('rest_id')) {
-          replies
-              .add(TweetChain(id: result['rest_id'], tweets: [TweetWithCard.fromGraphqlJson(result)], isPinned: false));
+          replies.add(
+            TweetChain(id: result['rest_id'], tweets: [TweetWithCard.fromGraphqlJson(result)], isPinned: false),
+          );
         } else {
           replies.add(TweetChain(id: entryId.substring(6), tweets: [TweetWithCard.tombstone({})], isPinned: false));
         }
@@ -371,15 +391,17 @@ class Twitter {
         var result = entry['content']['itemContent']['tweet_results']['result'];
         TweetWithCard? tweet = TweetWithCard.fromGraphqlJson(result);
 
-        replies
-            .add(TweetChain(id: result['rest_id'] ?? result['tweet']['rest_id'], tweets: [tweet], isPinned: isPinned));
+        replies.add(
+          TweetChain(id: result['rest_id'] ?? result['tweet']['rest_id'], tweets: [tweet], isPinned: isPinned),
+        );
       } else if (entryId.startsWith('profile-grid-')) {
         // We got a tweet queried from the media tab
         for (var mediaTweet in entry['content']['items']) {
           var result = mediaTweet['item']['itemContent']['tweet_results']['result'];
           TweetWithCard? tweet = TweetWithCard.fromGraphqlJson(result);
           replies.add(
-              TweetChain(id: result['rest_id'] ?? result['tweet']['rest_id'], tweets: [tweet], isPinned: isPinned));
+            TweetChain(id: result['rest_id'] ?? result['tweet']['rest_id'], tweets: [tweet], isPinned: isPinned),
+          );
         }
       }
 
@@ -399,8 +421,9 @@ class Twitter {
                 var tweet = TweetWithCard.fromGraphqlJson(item['item']['itemContent']['tweet_results']['result']);
                 tweets.add(tweet);
               } else {
-                var tweet =
-                    TweetWithCard.fromGraphqlJson(item['item']['itemContent']['tweet_results']['result']['tweet']);
+                var tweet = TweetWithCard.fromGraphqlJson(
+                  item['item']['itemContent']['tweet_results']['result']['tweet'],
+                );
                 tweets.add(tweet);
               }
             }
@@ -415,12 +438,64 @@ class Twitter {
   }
 
   static Future<TweetStatus> getTweet(String id, {String? cursor}) async {
-    Map<String, Object> defaultParam = {
-      "variables":
-          "{\"focalTweetId\":\"1696081434153214389\",\"referrer\":\"profile\",\"controller_data\":\"DAACDAABDAABCgABAAAAAAAAAAAKAAkNObspUxawBQAAAAA=\",\"with_rux_injections\":false,\"includePromotedContent\":false,\"withCommunity\":true,\"withQuickPromoteEligibilityTweetFields\":true,\"withBirdwatchNotes\":true,\"withVoice\":true,\"withV2Timeline\":true}",
-      "features":
-          "{\"rweb_lists_timeline_redesign_enabled\":true,\"responsive_web_graphql_exclude_directive_enabled\":true,\"verified_phone_label_enabled\":true,\"creator_subscriptions_tweet_preview_api_enabled\":true,\"responsive_web_graphql_timeline_navigation_enabled\":true,\"responsive_web_graphql_skip_user_profile_image_extensions_enabled\":false,\"tweetypie_unmention_optimization_enabled\":true,\"responsive_web_edit_tweet_api_enabled\":true,\"graphql_is_translatable_rweb_tweet_is_translatable_enabled\":true,\"view_counts_everywhere_api_enabled\":true,\"longform_notetweets_consumption_enabled\":true,\"responsive_web_twitter_article_tweet_consumption_enabled\":false,\"tweet_awards_web_tipping_enabled\":false,\"freedom_of_speech_not_reach_fetch_enabled\":true,\"standardized_nudges_misinfo\":true,\"tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled\":true,\"longform_notetweets_rich_text_read_enabled\":true,\"longform_notetweets_inline_media_enabled\":true,\"responsive_web_media_download_video_enabled\":false,\"responsive_web_enhance_cards_enabled\":false}",
-      "fieldToggles": "{\"withArticleRichContentState\":false}"
+    Map<String, dynamic> defaultParam = {
+      "variables": jsonEncode({
+        "focalTweetId": "0",
+        "with_rux_injections": false,
+        "rankingMode": "Relevance",
+        "includePromotedContent": true,
+        "withCommunity": true,
+        "withQuickPromoteEligibilityTweetFields": true,
+        "withBirdwatchNotes": true,
+        "withVoice": true,
+      }),
+      "features": jsonEncode({
+        "rweb_video_screen_enabled": false,
+        "profile_label_improvements_pcf_label_in_post_enabled": true,
+        "responsive_web_profile_redirect_enabled": false,
+        "rweb_tipjar_consumption_enabled": false,
+        "verified_phone_label_enabled": false,
+        "creator_subscriptions_tweet_preview_api_enabled": true,
+        "responsive_web_graphql_timeline_navigation_enabled": true,
+        "responsive_web_graphql_skip_user_profile_image_extensions_enabled": false,
+        "premium_content_api_read_enabled": false,
+        "communities_web_enable_tweet_community_results_fetch": true,
+        "c9s_tweet_anatomy_moderator_badge_enabled": true,
+        "responsive_web_grok_analyze_button_fetch_trends_enabled": false,
+        "responsive_web_grok_analyze_post_followups_enabled": true,
+        "responsive_web_jetfuel_frame": true,
+        "responsive_web_grok_share_attachment_enabled": true,
+        "responsive_web_grok_annotations_enabled": true,
+        "articles_preview_enabled": true,
+        "responsive_web_edit_tweet_api_enabled": true,
+        "graphql_is_translatable_rweb_tweet_is_translatable_enabled": true,
+        "view_counts_everywhere_api_enabled": true,
+        "longform_notetweets_consumption_enabled": true,
+        "responsive_web_twitter_article_tweet_consumption_enabled": true,
+        "tweet_awards_web_tipping_enabled": false,
+        "content_disclosure_indicator_enabled": true,
+        "content_disclosure_ai_generated_indicator_enabled": true,
+        "responsive_web_grok_show_grok_translated_post": false,
+        "responsive_web_grok_analysis_button_from_backend": true,
+        "post_ctas_fetch_enabled": true,
+        "freedom_of_speech_not_reach_fetch_enabled": true,
+        "standardized_nudges_misinfo": true,
+        "tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled": true,
+        "longform_notetweets_rich_text_read_enabled": true,
+        "longform_notetweets_inline_media_enabled": false,
+        "responsive_web_grok_image_annotation_enabled": true,
+        "responsive_web_grok_imagine_annotation_enabled": true,
+        "responsive_web_grok_community_note_auto_translation_is_enabled": false,
+        "responsive_web_enhance_cards_enabled": false,
+      }),
+      "fieldToggles": jsonEncode({
+        "withArticleRichContentState": true,
+        "withArticlePlainText": false,
+        "withArticleSummaryText": false,
+        "withArticleVoiceOver": false,
+        "withGrokAnalyze": false,
+        "withDisallowedReplyControls": false,
+      }),
     };
 
     Map<String, dynamic> variables = json.decode(defaultParam["variables"].toString());
@@ -432,8 +507,9 @@ class Twitter {
 
     defaultParam["variables"] = json.encode(variables);
 
-    var response = await _twitterApi.client
-        .get(Uri.https('twitter.com', '/i/api/graphql/3XDB26fBve-MmjHaWTUZxA/TweetDetail', defaultParam));
+    var response = await _twitterApi.client.get(
+      Uri.https('x.com', '/i/api/graphql/xIYgDwjboktoFeXe_fgacw/TweetDetail', defaultParam),
+    );
 
     var result = json.decode(response.body);
 
@@ -459,8 +535,13 @@ class Twitter {
     return TweetStatus(chains: chains, cursorBottom: cursorBottom, cursorTop: cursorTop);
   }
 
-  static Future<TweetStatus> searchTweets(String query, bool includeReplies,
-      {int limit = 20, String? cursor, String product = "Latest"}) async {
+  static Future<TweetStatus> searchTweets(
+    String query,
+    bool includeReplies, {
+    int limit = 20,
+    String? cursor,
+    String product = "Latest",
+  }) async {
     var variables = {
       "rawQuery": query,
       "count": limit.toString(),
@@ -470,51 +551,53 @@ class Twitter {
     };
 
     var features = {
-      "rweb_video_screen_enabled":false,
-      "profile_label_improvements_pcf_label_in_post_enabled":true,
-      "responsive_web_profile_redirect_enabled":false,
-      "rweb_tipjar_consumption_enabled":false,
-      "verified_phone_label_enabled":false,
-      "creator_subscriptions_tweet_preview_api_enabled":true,
-      "responsive_web_graphql_timeline_navigation_enabled":true,
-      "responsive_web_graphql_skip_user_profile_image_extensions_enabled":false,
-      "premium_content_api_read_enabled":false,
-      "communities_web_enable_tweet_community_results_fetch":true,
-      "c9s_tweet_anatomy_moderator_badge_enabled":true,
-      "responsive_web_grok_analyze_button_fetch_trends_enabled":false,
-      "responsive_web_grok_analyze_post_followups_enabled":true,
-      "responsive_web_jetfuel_frame":true,
-      "responsive_web_grok_share_attachment_enabled":true,
-      "responsive_web_grok_annotations_enabled":true,
-      "articles_preview_enabled":true,
-      "responsive_web_edit_tweet_api_enabled":true,
-      "graphql_is_translatable_rweb_tweet_is_translatable_enabled":true,
-      "view_counts_everywhere_api_enabled":true,
-      "longform_notetweets_consumption_enabled":true,
-      "responsive_web_twitter_article_tweet_consumption_enabled":true,
-      "tweet_awards_web_tipping_enabled":false,
-      "content_disclosure_indicator_enabled":true,
-      "content_disclosure_ai_generated_indicator_enabled":true,
-      "responsive_web_grok_show_grok_translated_post":false,
-      "responsive_web_grok_analysis_button_from_backend":true,
-      "post_ctas_fetch_enabled":true,
-      "freedom_of_speech_not_reach_fetch_enabled":true,
-      "standardized_nudges_misinfo":true,
-      "tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled":true,
-      "longform_notetweets_rich_text_read_enabled":true,
-      "longform_notetweets_inline_media_enabled":true,
-      "responsive_web_grok_image_annotation_enabled":true,
-      "responsive_web_grok_imagine_annotation_enabled":true,
-      "responsive_web_grok_community_note_auto_translation_is_enabled":false,
-      "responsive_web_enhance_cards_enabled":false
+      "rweb_video_screen_enabled": false,
+      "profile_label_improvements_pcf_label_in_post_enabled": true,
+      "responsive_web_profile_redirect_enabled": false,
+      "rweb_tipjar_consumption_enabled": false,
+      "verified_phone_label_enabled": false,
+      "creator_subscriptions_tweet_preview_api_enabled": true,
+      "responsive_web_graphql_timeline_navigation_enabled": true,
+      "responsive_web_graphql_skip_user_profile_image_extensions_enabled": false,
+      "premium_content_api_read_enabled": false,
+      "communities_web_enable_tweet_community_results_fetch": true,
+      "c9s_tweet_anatomy_moderator_badge_enabled": true,
+      "responsive_web_grok_analyze_button_fetch_trends_enabled": false,
+      "responsive_web_grok_analyze_post_followups_enabled": true,
+      "responsive_web_jetfuel_frame": true,
+      "responsive_web_grok_share_attachment_enabled": true,
+      "responsive_web_grok_annotations_enabled": true,
+      "articles_preview_enabled": true,
+      "responsive_web_edit_tweet_api_enabled": true,
+      "graphql_is_translatable_rweb_tweet_is_translatable_enabled": true,
+      "view_counts_everywhere_api_enabled": true,
+      "longform_notetweets_consumption_enabled": true,
+      "responsive_web_twitter_article_tweet_consumption_enabled": true,
+      "tweet_awards_web_tipping_enabled": false,
+      "content_disclosure_indicator_enabled": true,
+      "content_disclosure_ai_generated_indicator_enabled": true,
+      "responsive_web_grok_show_grok_translated_post": false,
+      "responsive_web_grok_analysis_button_from_backend": true,
+      "post_ctas_fetch_enabled": true,
+      "freedom_of_speech_not_reach_fetch_enabled": true,
+      "standardized_nudges_misinfo": true,
+      "tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled": true,
+      "longform_notetweets_rich_text_read_enabled": true,
+      "longform_notetweets_inline_media_enabled": true,
+      "responsive_web_grok_image_annotation_enabled": true,
+      "responsive_web_grok_imagine_annotation_enabled": true,
+      "responsive_web_grok_community_note_auto_translation_is_enabled": false,
+      "responsive_web_enhance_cards_enabled": false,
     };
 
     if (cursor != null) {
       variables['cursor'] = cursor;
     }
 
-    var uri = Uri.https('x.com', '/i/api/graphql/9AW3D-T7t9Vkvfdmq2L-iQ/SearchTimeline',
-        {'variables': jsonEncode(variables), 'features': jsonEncode(features)});
+    var uri = Uri.https('x.com', '/i/api/graphql/9AW3D-T7t9Vkvfdmq2L-iQ/SearchTimeline', {
+      'variables': jsonEncode(variables),
+      'features': jsonEncode(features),
+    });
 
     var response = await _twitterApi.client.get(uri);
     var result = json.decode(response.body);
@@ -535,7 +618,7 @@ class Twitter {
       "product": 'People',
       "withDownvotePerspective": false,
       "withReactionsMetadata": false,
-      "withReactionsPerspective": false
+      "withReactionsPerspective": false,
     };
 
     var searchFeatures = {
@@ -558,15 +641,17 @@ class Twitter {
       "rweb_video_timestamps_enabled": true,
       "longform_notetweets_rich_text_read_enabled": true,
       "longform_notetweets_inline_media_enabled": true,
-      "responsive_web_enhance_cards_enabled": false
+      "responsive_web_enhance_cards_enabled": false,
     };
 
     if (cursor != null) {
       variables['cursor'] = cursor;
     }
 
-    var uri = Uri.https('twitter.com', '/i/api/graphql/-KWrbTBsPifMuLUqqDiU_A/SearchTimeline',
-        {'variables': jsonEncode(variables), 'features': jsonEncode(searchFeatures)});
+    var uri = Uri.https('twitter.com', '/i/api/graphql/-KWrbTBsPifMuLUqqDiU_A/SearchTimeline', {
+      'variables': jsonEncode(variables),
+      'features': jsonEncode(searchFeatures),
+    });
 
     var response = await _twitterApi.client.get(uri);
     if (response.body.isEmpty) {
@@ -578,13 +663,15 @@ class Twitter {
       return [];
     }
 
-    List instructions =
-        List.from(result?['data']?['search_by_raw_query']?['search_timeline']?['timeline']?['instructions'] ?? []);
+    List instructions = List.from(
+      result?['data']?['search_by_raw_query']?['search_timeline']?['timeline']?['instructions'] ?? [],
+    );
     if (instructions.isEmpty) {
       return [];
     }
     List addEntries = List.from(
-        instructions.firstWhere((e) => e['type'] == 'TimelineAddEntries', orElse: () => null)?['entries'] ?? []);
+      instructions.firstWhere((e) => e['type'] == 'TimelineAddEntries', orElse: () => null)?['entries'] ?? [],
+    );
     if (addEntries.isEmpty) {
       return [];
     }
@@ -593,10 +680,14 @@ class Twitter {
         .where((entry) => entry['entryId']?.startsWith('user-'))
         .where((entry) => entry['content']?['itemContent']?['user_results']?['result']?['legacy'] != null)
         .map((entry) {
-      var res = entry['content']['itemContent']['user_results']['result'];
-      return UserWithExtra.fromJson(
-          {...res['legacy'], 'id_str': res['rest_id'], 'ext_is_blue_verified': res['is_blue_verified']});
-    }).toList();
+          var res = entry['content']['itemContent']['user_results']['result'];
+          return UserWithExtra.fromJson({
+            ...res['legacy'],
+            'id_str': res['rest_id'],
+            'ext_is_blue_verified': res['is_blue_verified'],
+          });
+        })
+        .toList();
   }
 
   static Future<List<TrendLocation>> getTrendLocations() async {
@@ -636,7 +727,7 @@ class Twitter {
           "{\"userId\":\"160534877\",\"count\":$count,\"includePromotedContent\":false,\"withQuickPromoteEligibilityTweetFields\":true,\"withVoice\":true,\"withV2Timeline\":true}",
       "features":
           "{\"rweb_lists_timeline_redesign_enabled\":true,\"responsive_web_graphql_exclude_directive_enabled\":true,\"verified_phone_label_enabled\":true,\"creator_subscriptions_tweet_preview_api_enabled\":true,\"responsive_web_graphql_timeline_navigation_enabled\":true,\"responsive_web_graphql_skip_user_profile_image_extensions_enabled\":false,\"tweetypie_unmention_optimization_enabled\":true,\"responsive_web_edit_tweet_api_enabled\":true,\"graphql_is_translatable_rweb_tweet_is_translatable_enabled\":true,\"view_counts_everywhere_api_enabled\":true,\"longform_notetweets_consumption_enabled\":true,\"responsive_web_twitter_article_tweet_consumption_enabled\":false,\"tweet_awards_web_tipping_enabled\":false,\"freedom_of_speech_not_reach_fetch_enabled\":true,\"standardized_nudges_misinfo\":true,\"tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled\":true,\"longform_notetweets_rich_text_read_enabled\":true,\"longform_notetweets_inline_media_enabled\":true,\"responsive_web_media_download_video_enabled\":false,\"responsive_web_enhance_cards_enabled\":false}",
-      "fieldToggles": "{\"withAuxiliaryUserLabels\":false,\"withArticleRichContentState\":false}"
+      "fieldToggles": "{\"withAuxiliaryUserLabels\":false,\"withArticleRichContentState\":false}",
     };
 
     Map<String, dynamic> variables = json.decode(defaultUserTweetsParam["variables"].toString());
@@ -646,8 +737,9 @@ class Twitter {
     }
     defaultUserTweetsParam["variables"] = json.encode(variables);
 
-    var response = await _twitterApi.client
-        .get(Uri.https('twitter.com', 'i/api/graphql/W4Tpu1uueTGK53paUgxF0Q/HomeTimeline', defaultUserTweetsParam));
+    var response = await _twitterApi.client.get(
+      Uri.https('twitter.com', 'i/api/graphql/W4Tpu1uueTGK53paUgxF0Q/HomeTimeline', defaultUserTweetsParam),
+    );
     var result = json.decode(response.body);
     //if this page is not first one on the profile page, dont add pinned tweet
     if (variables['cursor'] != null) showPinnedTweet = false;
@@ -663,34 +755,34 @@ class Twitter {
     );
   }
 
-  static Future<TweetStatus> getTweets(String id, String type, List<String> pinnedTweets,
-      {int count = 10,
-      String? cursor,
-      bool includeReplies = true,
-      bool includeRetweets = true,
-      required int Function() getTweetsCounter,
-      required void Function() incrementTweetsCounter}) async {
+  static Future<TweetStatus> getTweets(
+    String id,
+    String type,
+    List<String> pinnedTweets, {
+    int count = 10,
+    String? cursor,
+    bool includeReplies = true,
+    bool includeRetweets = true,
+    required int Function() getTweetsCounter,
+    required void Function() incrementTweetsCounter,
+  }) async {
     bool showPinnedTweet = true;
-    var query = {
-      ...defaultParams,
-      'count': count.toString(),
-    };
+    var query = {...defaultParams, 'count': count.toString()};
 
     Map<String, Object> defaultUserTweetsParam = {
-      "variables":
-          "{\"userId\":\"160534877\",\"count\":20,\"includePromotedContent\":false,\"withQuickPromoteEligibilityTweetFields\":true,\"withVoice\":true,\"withV2Timeline\":true}",
-      "features":
-          "{\"rweb_lists_timeline_redesign_enabled\":true,\"responsive_web_graphql_exclude_directive_enabled\":true,\"verified_phone_label_enabled\":true,\"creator_subscriptions_tweet_preview_api_enabled\":true,\"responsive_web_graphql_timeline_navigation_enabled\":true,\"responsive_web_graphql_skip_user_profile_image_extensions_enabled\":false,\"tweetypie_unmention_optimization_enabled\":true,\"responsive_web_edit_tweet_api_enabled\":true,\"graphql_is_translatable_rweb_tweet_is_translatable_enabled\":true,\"view_counts_everywhere_api_enabled\":true,\"longform_notetweets_consumption_enabled\":true,\"responsive_web_twitter_article_tweet_consumption_enabled\":false,\"tweet_awards_web_tipping_enabled\":false,\"freedom_of_speech_not_reach_fetch_enabled\":true,\"standardized_nudges_misinfo\":true,\"tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled\":true,\"longform_notetweets_rich_text_read_enabled\":true,\"longform_notetweets_inline_media_enabled\":true,\"responsive_web_media_download_video_enabled\":false,\"responsive_web_enhance_cards_enabled\":false}",
-      "fieldToggles": "{\"withAuxiliaryUserLabels\":false,\"withArticleRichContentState\":false}"
-    };
-
-    if (includeReplies) {
-      defaultUserTweetsParam["features"] = jsonEncode({
+      "variables": jsonEncode({
+        "userId": "8341362",
+        "count": 20,
+        "includePromotedContent": true,
+        "withQuickPromoteEligibilityTweetFields": true,
+        "withVoice": true,
+      }),
+      "features": jsonEncode({
         "rweb_video_screen_enabled": false,
-        "payments_enabled": false,
+        "rweb_cashtags_enabled": false,
         "profile_label_improvements_pcf_label_in_post_enabled": true,
         "responsive_web_profile_redirect_enabled": false,
-        "rweb_tipjar_consumption_enabled": true,
+        "rweb_tipjar_consumption_enabled": false,
         "verified_phone_label_enabled": false,
         "creator_subscriptions_tweet_preview_api_enabled": true,
         "responsive_web_graphql_timeline_navigation_enabled": true,
@@ -702,24 +794,69 @@ class Twitter {
         "responsive_web_grok_analyze_post_followups_enabled": true,
         "responsive_web_jetfuel_frame": true,
         "responsive_web_grok_share_attachment_enabled": true,
+        "responsive_web_grok_annotations_enabled": true,
         "articles_preview_enabled": true,
         "responsive_web_edit_tweet_api_enabled": true,
         "graphql_is_translatable_rweb_tweet_is_translatable_enabled": true,
         "view_counts_everywhere_api_enabled": true,
         "longform_notetweets_consumption_enabled": true,
         "responsive_web_twitter_article_tweet_consumption_enabled": true,
-        "tweet_awards_web_tipping_enabled": false,
-        "responsive_web_grok_show_grok_translated_post": false,
+        "content_disclosure_indicator_enabled": true,
+        "content_disclosure_ai_generated_indicator_enabled": true,
+        "responsive_web_grok_show_grok_translated_post": true,
         "responsive_web_grok_analysis_button_from_backend": true,
-        "creator_subscriptions_quote_tweet_preview_enabled": false,
+        "post_ctas_fetch_enabled": true,
         "freedom_of_speech_not_reach_fetch_enabled": true,
         "standardized_nudges_misinfo": true,
         "tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled": true,
         "longform_notetweets_rich_text_read_enabled": true,
-        "longform_notetweets_inline_media_enabled": true,
+        "longform_notetweets_inline_media_enabled": false,
         "responsive_web_grok_image_annotation_enabled": true,
         "responsive_web_grok_imagine_annotation_enabled": true,
-        "responsive_web_grok_community_note_auto_translation_is_enabled": false,
+        "responsive_web_grok_community_note_auto_translation_is_enabled": true,
+        "responsive_web_enhance_cards_enabled": false,
+      }),
+      "fieldToggles": jsonEncode({"withArticlePlainText": false}),
+    };
+
+    if (includeReplies) {
+      defaultUserTweetsParam["features"] = jsonEncode({
+        "rweb_video_screen_enabled": false,
+        "rweb_cashtags_enabled": false,
+        "profile_label_improvements_pcf_label_in_post_enabled": true,
+        "responsive_web_profile_redirect_enabled": false,
+        "rweb_tipjar_consumption_enabled": false,
+        "verified_phone_label_enabled": false,
+        "creator_subscriptions_tweet_preview_api_enabled": true,
+        "responsive_web_graphql_timeline_navigation_enabled": true,
+        "responsive_web_graphql_skip_user_profile_image_extensions_enabled": false,
+        "premium_content_api_read_enabled": false,
+        "communities_web_enable_tweet_community_results_fetch": true,
+        "c9s_tweet_anatomy_moderator_badge_enabled": true,
+        "responsive_web_grok_analyze_button_fetch_trends_enabled": false,
+        "responsive_web_grok_analyze_post_followups_enabled": true,
+        "responsive_web_jetfuel_frame": true,
+        "responsive_web_grok_share_attachment_enabled": true,
+        "responsive_web_grok_annotations_enabled": true,
+        "articles_preview_enabled": true,
+        "responsive_web_edit_tweet_api_enabled": true,
+        "graphql_is_translatable_rweb_tweet_is_translatable_enabled": true,
+        "view_counts_everywhere_api_enabled": true,
+        "longform_notetweets_consumption_enabled": true,
+        "responsive_web_twitter_article_tweet_consumption_enabled": true,
+        "content_disclosure_indicator_enabled": true,
+        "content_disclosure_ai_generated_indicator_enabled": true,
+        "responsive_web_grok_show_grok_translated_post": true,
+        "responsive_web_grok_analysis_button_from_backend": true,
+        "post_ctas_fetch_enabled": true,
+        "freedom_of_speech_not_reach_fetch_enabled": true,
+        "standardized_nudges_misinfo": true,
+        "tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled": true,
+        "longform_notetweets_rich_text_read_enabled": true,
+        "longform_notetweets_inline_media_enabled": false,
+        "responsive_web_grok_image_annotation_enabled": true,
+        "responsive_web_grok_imagine_annotation_enabled": true,
+        "responsive_web_grok_community_note_auto_translation_is_enabled": true,
         "responsive_web_enhance_cards_enabled": false
       });
 
@@ -760,7 +897,7 @@ class Twitter {
         "responsive_web_grok_image_annotation_enabled": true,
         "responsive_web_grok_imagine_annotation_enabled": true,
         "responsive_web_grok_community_note_auto_translation_is_enabled": false,
-        "responsive_web_enhance_cards_enabled": false
+        "responsive_web_enhance_cards_enabled": false,
       });
       defaultUserTweetsParam["filedToggles"] = jsonEncode({"withArticlePlainText": false});
     }
@@ -792,8 +929,16 @@ class Twitter {
 
     //if this page is not first one on the profile page, dont add pinned tweet
     if (variables['cursor'] != null) showPinnedTweet = false;
-    return createUnconversationedChains(result, 'tweet', pinnedTweets, includeReplies == false, includeReplies,
-        showPinnedTweet, getTweetsCounter, incrementTweetsCounter);
+    return createUnconversationedChains(
+      result,
+      'tweet',
+      pinnedTweets,
+      includeReplies == false,
+      includeReplies,
+      showPinnedTweet,
+      getTweetsCounter,
+      incrementTweetsCounter,
+    );
   }
 
   static String? getCursor(List<dynamic> addEntries, List<dynamic> repEntries, String legacyType, String type) {
@@ -822,10 +967,11 @@ class Twitter {
     } else {
       // Look for a "replaceEntry" with the cursor
       var cursorReplaceEntry = repEntries.firstWhere(
-          (e) => e.containsKey('replaceEntry')
-              ? e['replaceEntry']['entryIdToReplace'].contains(type)
-              : e['entry']['content']['cursorType'].contains(type),
-          orElse: () => null);
+        (e) => e.containsKey('replaceEntry')
+            ? e['replaceEntry']['entryIdToReplace'].contains(type)
+            : e['entry']['content']['cursorType'].contains(type),
+        orElse: () => null,
+      );
 
       if (cursorReplaceEntry != null) {
         cursor = cursorReplaceEntry.containsKey('replaceEntry')
@@ -837,8 +983,13 @@ class Twitter {
     return cursor;
   }
 
-  static TweetStatus createUnconversationedChainsGraphql(Map<String, dynamic> result, String tweetIndicator,
-      List<String> pinnedTweets, bool mapToThreads, bool includeReplies) {
+  static TweetStatus createUnconversationedChainsGraphql(
+    Map<String, dynamic> result,
+    String tweetIndicator,
+    List<String> pinnedTweets,
+    bool mapToThreads,
+    bool includeReplies,
+  ) {
     var instructions = List.from(result['timeline']['instructions']);
     if (instructions.isEmpty || !instructions.any((e) => e['type'] == 'TimelineAddEntries')) {
       return TweetStatus(chains: [], cursorBottom: null, cursorTop: null);
@@ -854,24 +1005,27 @@ class Twitter {
 
     // First, get all the IDs of the tweets we need to display
     var tweetEntries = addEntries
-        .where((e) =>
-            e['entryId'].contains(tweetIndicator) &&
-            e['content']?['itemContent']?['tweet_results']?['result']?['rest_id'] != null)
+        .where(
+          (e) =>
+              e['entryId'].contains(tweetIndicator) &&
+              e['content']?['itemContent']?['tweet_results']?['result']?['rest_id'] != null,
+        )
         .sorted((a, b) => b['sortIndex'].compareTo(a['sortIndex']))
         .map((e) => e['content']['itemContent']['tweet_results']['result']['rest_id'])
         .cast<String?>()
         .toList();
 
-    Map<String, List<TweetWithCard>> conversations =
-        tweets.values.where((e) => tweetEntries.contains(e.idStr)).groupBy((e) {
-      // TODO: I don't think a flag is the right way to handle this
-      if (mapToThreads) {
-        // Then group the tweets-to-display by their conversation ID
-        return e.conversationIdStr;
-      }
+    Map<String, List<TweetWithCard>> conversations = tweets.values.where((e) => tweetEntries.contains(e.idStr)).groupBy(
+      (e) {
+        // TODO: I don't think a flag is the right way to handle this
+        if (mapToThreads) {
+          // Then group the tweets-to-display by their conversation ID
+          return e.conversationIdStr;
+        }
 
-      return e.idStr;
-    }).cast<String, List<TweetWithCard>>();
+        return e.idStr;
+      },
+    ).cast<String, List<TweetWithCard>>();
 
     List<TweetChain> chains = [];
 
@@ -990,7 +1144,10 @@ class Twitter {
   }
 
   static Map<String, TweetWithCard> _createTweetsGraphql(
-      String entryPrefix, List<dynamic> allTweets, bool includeReplies) {
+    String entryPrefix,
+    List<dynamic> allTweets,
+    bool includeReplies,
+  ) {
     bool includeTweet(dynamic t) {
       // Exclude any items that aren't tweets
       if (!t['entryId'].startsWith(entryPrefix)) {
@@ -1010,14 +1167,16 @@ class Twitter {
 
     var filteredTweets = allTweets.where(includeTweet);
 
-    var globalTweets = List.from(filteredTweets.map((e) {
-      var elm = e['content']['itemContent']['tweet_results']['result'];
-      if (elm['rest_id'] == null && elm['tweet'] != null) {
-        elm = elm['tweet'];
-      }
+    var globalTweets = List.from(
+      filteredTweets.map((e) {
+        var elm = e['content']['itemContent']['tweet_results']['result'];
+        if (elm['rest_id'] == null && elm['tweet'] != null) {
+          elm = elm['tweet'];
+        }
 
-      return elm;
-    }));
+        return elm;
+      }),
+    );
 
     var tweets = [];
     try {
@@ -1052,7 +1211,8 @@ class TweetWithCard extends Tweet {
   TweetWithCard? quotedStatusWithCard;
   TweetWithCard? retweetedStatusWithCard;
   bool? isTombstone;
-  TweetWithCard? birdwatchQuotedStatus;  // Community notes
+  TweetWithCard? birdwatchQuotedStatus; // Community notes
+  Article? article;
 
   TweetWithCard();
 
@@ -1064,6 +1224,7 @@ class TweetWithCard extends Tweet {
     json['quotedStatusWithCard'] = quotedStatusWithCard?.toJson();
     json['retweetedStatusWithCard'] = retweetedStatusWithCard?.toJson();
     json['isTombstone'] = isTombstone;
+    json['article'] = article?.toJson();
 
     return json;
   }
@@ -1102,14 +1263,16 @@ class TweetWithCard extends Tweet {
     tweetWithCard.quoteCount = tweet.quoteCount;
     tweetWithCard.quotedStatusIdStr = tweet.quotedStatusIdStr;
     tweetWithCard.quotedStatusPermalink = tweet.quotedStatusPermalink;
-    tweetWithCard.quotedStatusWithCard =
-        e['quotedStatusWithCard'] == null ? null : TweetWithCard.fromJson(e['quotedStatusWithCard']);
+    tweetWithCard.quotedStatusWithCard = e['quotedStatusWithCard'] == null
+        ? null
+        : TweetWithCard.fromJson(e['quotedStatusWithCard']);
     tweetWithCard.replyCount = tweet.replyCount;
     tweetWithCard.retweetCount = tweet.retweetCount;
     tweetWithCard.retweeted = tweet.retweeted;
     tweetWithCard.retweetedStatus = tweet.retweetedStatus;
-    tweetWithCard.retweetedStatusWithCard =
-        e['retweetedStatusWithCard'] == null ? null : TweetWithCard.fromJson(e['retweetedStatusWithCard']);
+    tweetWithCard.retweetedStatusWithCard = e['retweetedStatusWithCard'] == null
+        ? null
+        : TweetWithCard.fromJson(e['retweetedStatusWithCard']);
     tweetWithCard.source = tweet.source;
     tweetWithCard.text = tweet.text;
     tweetWithCard.user = tweet.user;
@@ -1118,6 +1281,7 @@ class TweetWithCard extends Tweet {
     tweetWithCard.place = tweet.place;
     tweetWithCard.possiblySensitive = tweet.possiblySensitive;
     tweetWithCard.possiblySensitiveAppealable = tweet.possiblySensitiveAppealable;
+    tweetWithCard.article = e['article'] == null ? null : Article.fromJson(e['article']);
 
     return tweetWithCard;
   }
@@ -1133,12 +1297,11 @@ class TweetWithCard extends Tweet {
       retweetedStatus = TweetWithCard.fromGraphqlJson(result['legacy']['retweeted_status_result']['result']!);
     }
 
-    if (result['quoted_status_result'] != null && result['quoted_status_result']['result'] != null){
+    if (result['quoted_status_result'] != null && result['quoted_status_result']['result'] != null) {
       // tweets that limit who can reply (TweetWithVisibilityResults) are wrapped in another layer
-      var quotedTweetResult =
-        result['quoted_status_result']['result']?['__typename'] == 'TweetWithVisibilityResults'
-        ? result['quoted_status_result']['result']['tweet']
-        : result['quoted_status_result']['result'];
+      var quotedTweetResult = result['quoted_status_result']['result']?['__typename'] == 'TweetWithVisibilityResults'
+          ? result['quoted_status_result']['result']['tweet']
+          : result['quoted_status_result']['result'];
       quotedStatus = TweetWithCard.fromGraphqlJson(quotedTweetResult);
     }
 
@@ -1160,14 +1323,7 @@ class TweetWithCard extends Tweet {
       return TweetWithCard.tombstone(result['tombstone']!);
     }
 
-    var tweet = TweetWithCard.fromData(
-      result['legacy'],
-      noteText,
-      noteEntities,
-      user,
-      retweetedStatus,
-      quotedStatus,
-    );
+    var tweet = TweetWithCard.fromData(result['legacy'], noteText, noteEntities, user, retweetedStatus, quotedStatus);
 
     if (tweet.card == null && result['card']?['legacy'] != null) {
       tweet.card = result['card']['legacy'];
@@ -1185,6 +1341,16 @@ class TweetWithCard extends Tweet {
       tweet.birdwatchQuotedStatus = TweetWithCard.fromJson(birdwatchSubtitle);
     }
 
+    final article = result['article']?["article_results"]?["result"] ?? result['article']?['article'];
+
+    if (article != null) {
+      tweet.article = Article.fromGraphqlJson(
+        article,
+        tweet.idStr ?? "",
+        tweet.user?.screenName ?? "",
+      );
+    }
+
     return tweet;
   }
 
@@ -1194,7 +1360,7 @@ class TweetWithCard extends Tweet {
     newBirdwatch['text'] = text;
     newBirdwatch['display_text_range'] = [0, text.length - 1];
     var entities = birdwatch['entities'];
-    newBirdwatch['entities'] = { "urls": []};
+    newBirdwatch['entities'] = {"urls": []};
     for (final entity in entities) {
       int fromIndex = entity['fromIndex'];
       int toIndex = entity['toIndex'];
@@ -1204,12 +1370,11 @@ class TweetWithCard extends Tweet {
         'display_url': displayedUrl,
         'expanded_url': url,
         'url': url,
-        'indices': [fromIndex, toIndex]
+        'indices': [fromIndex, toIndex],
       });
     }
     return newBirdwatch;
   }
-
 
   factory TweetWithCard.fromCardJson(Map<String, dynamic> tweets, Map<String, dynamic> users, Map<String, dynamic> e) {
     var user = e['user_id_str'] == null ? null : UserWithExtra.fromJson(users[e['user_id_str']]);
@@ -1228,8 +1393,14 @@ class TweetWithCard extends Tweet {
     return TweetWithCard.fromData(e, null, null, user, retweetedStatus, quotedStatus);
   }
 
-  factory TweetWithCard.fromData(Map<String, dynamic> e, String? noteText, Entities? noteEntities, UserWithExtra? user,
-      TweetWithCard? retweetedStatus, TweetWithCard? quotedStatus) {
+  factory TweetWithCard.fromData(
+    Map<String, dynamic> e,
+    String? noteText,
+    Entities? noteEntities,
+    UserWithExtra? user,
+    TweetWithCard? retweetedStatus,
+    TweetWithCard? quotedStatus,
+  ) {
     TweetWithCard tweet = TweetWithCard();
     tweet.card = e['card'];
     tweet.conversationIdStr = e['conversation_id_str'];
@@ -1249,8 +1420,9 @@ class TweetWithCard extends Tweet {
     tweet.possiblySensitive = e['possibly_sensitive'] as bool?;
     tweet.quoteCount = e['quote_count'] as int?;
     tweet.quotedStatusIdStr = e['quoted_status_id_str'] as String?;
-    tweet.quotedStatusPermalink =
-        e['quoted_status_permalink'] == null ? null : QuotedStatusPermalink.fromJson(e['quoted_status_permalink']);
+    tweet.quotedStatusPermalink = e['quoted_status_permalink'] == null
+        ? null
+        : QuotedStatusPermalink.fromJson(e['quoted_status_permalink']);
     tweet.replyCount = e['reply_count'] as int?;
     tweet.retweetCount = e['retweet_count'] as int?;
     tweet.retweeted = e['retweeted'] as bool?;

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -476,6 +476,8 @@
   "community_notes_header": "Users added context",
   "share_tweet_as_image": "Share tweet as image",
   "show_in_main_feed": "Show in main feed",
-  "hide_from_main_feed": "Hide from main feed"
+  "hide_from_main_feed": "Hide from main feed",
+  "share_article_link": "Share article link",
+  "share_article_as_image": "Share article as image"
 }
 

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -548,5 +548,7 @@
   "community_notes_header": "Contexte ajouté par les utilisateurs",
   "share_tweet_as_image": "Partager le tweet en tant qu'image",
   "show_in_main_feed": "Afficher dans le fil principal",
-  "hide_from_main_feed": "Masquer du fil principal"
+  "hide_from_main_feed": "Masquer du fil principal",
+  "share_article_link": "Partager le lien de l'article",
+  "share_article_as_image": "Partager l'article en tant qu'image"
 }

--- a/lib/profile/profile.dart
+++ b/lib/profile/profile.dart
@@ -197,19 +197,6 @@ class _ProfileScreenBodyState extends State<ProfileScreenBody> with TickerProvid
     nestedScrollViewKey.currentState?.outerController.jumpTo(0);
   }
 
-  Media createMediaFromUrl(String? url, double? height) {
-    Media media = Media();
-    if (url != null) {
-      ExtendedImage.network(url, fit: BoxFit.fitWidth, height: height);
-      media.url = url;
-      media.mediaUrlHttps = url;
-      media.displayUrl = url;
-      media.expandedUrl = url;
-      media.type = 'photo';
-    }
-    return media;
-  }
-
   @override
   Widget build(BuildContext context) {
     // TODO: This shouldn't happen before the profile is loaded

--- a/lib/tweet/_media.dart
+++ b/lib/tweet/_media.dart
@@ -195,6 +195,19 @@ class TweetMediaView extends StatefulWidget {
   State<TweetMediaView> createState() => _TweetMediaViewState();
 }
 
+Media createMediaFromUrl(String? url, double? height) {
+  Media media = Media();
+  if (url != null) {
+    ExtendedImage.network(url, fit: BoxFit.fitWidth, height: height);
+    media.url = url;
+    media.mediaUrlHttps = url;
+    media.displayUrl = url;
+    media.expandedUrl = url;
+    media.type = 'photo';
+  }
+  return media;
+}
+
 class _TweetMediaViewState extends State<TweetMediaView> {
   late Media _media;
 

--- a/lib/tweet/_video.dart
+++ b/lib/tweet/_video.dart
@@ -27,16 +27,8 @@ class TweetVideoMetadata {
 
   TweetVideoMetadata(this.aspectRatio, this.imageUrl, this.streamUrlsBuilder);
 
-  factory TweetVideoMetadata.fromMedia(Media media) {
-    var aspectRatio = media.videoInfo?.aspectRatio == null
-        ? 1.0
-        : media.videoInfo!.aspectRatio![0] / media.videoInfo!.aspectRatio![1];
-
-    var variants = media.videoInfo?.variants ?? [];
+  static Future<TweetVideoUrls> Function() streamUrlsBuilderFromVariants(List<Variant> variants) {
     var streamUrl = variants[0].url!;
-    var imageUrl = media.mediaUrlHttps!;
-
-    // Find the MP4 video with the highest bitrate
     var downloadUrl = variants
         .where((e) => e.bitrate != null)
         .where((e) => e.url != null)
@@ -45,7 +37,18 @@ class TweetVideoMetadata {
         .map((e) => e.url)
         .firstWhereOrNull((e) => e != null);
 
-    return TweetVideoMetadata(aspectRatio, imageUrl, () async => TweetVideoUrls(streamUrl, downloadUrl));
+    return () async => TweetVideoUrls(streamUrl, downloadUrl);
+  }
+
+  factory TweetVideoMetadata.fromMedia(Media media) {
+    var aspectRatio = media.videoInfo?.aspectRatio == null
+        ? 1.0
+        : media.videoInfo!.aspectRatio![0] / media.videoInfo!.aspectRatio![1];
+
+    var variants = media.videoInfo?.variants ?? [];
+    var imageUrl = media.mediaUrlHttps!;
+
+    return TweetVideoMetadata(aspectRatio, imageUrl, streamUrlsBuilderFromVariants(variants));
   }
 }
 

--- a/lib/tweet/tweet.dart
+++ b/lib/tweet/tweet.dart
@@ -15,6 +15,7 @@ import 'package:quax/status.dart';
 import 'package:quax/tweet/_ExpandableTweetText.dart';
 import 'package:quax/tweet/_card.dart';
 import 'package:quax/tweet/_media.dart';
+import 'package:quax/article/article.dart';
 import 'package:quax/ui/dates.dart';
 import 'package:quax/ui/errors.dart';
 import 'package:quax/user.dart';
@@ -182,6 +183,140 @@ class TweetTileState extends State<TweetTile> with SingleTickerProviderStateMixi
       icon: Icon(icon, size: 20, color: color),
       onPressed: onPressed,
       label: Text(label, style: TextStyle(color: color, fontSize: 14)),
+    );
+  }
+
+  Widget _buildTranslateButton(Locale locale) {
+    switch (_translationStatus) {
+      case TranslationStatus.original:
+        return _createFooterIconButton(Icons.translate, buttonsColor(context), null, () async => onClickTranslate(context, locale));
+      case TranslationStatus.translating:
+        return const Padding(
+          padding: EdgeInsets.symmetric(horizontal: 24),
+          child: SizedBox(width: 16, height: 16, child: CircularProgressIndicator()),
+        );
+      case TranslationStatus.translationFailed:
+        return _createFooterIconButton(
+            Icons.translate,
+            Colors.red.harmonizeWith(Theme.of(context).colorScheme.primary),
+            null,
+            () async => onClickTranslate(context, locale));
+      case TranslationStatus.translated:
+        return _createFooterIconButton(
+            Icons.translate, Theme.of(context).colorScheme.primary, null, () async => onClickShowOriginal());
+    }
+  }
+
+  Widget _buildFooterBar(TweetWithCard tweet, String tweetText, String shareBaseUrl, Locale locale, NumberFormat numberFormat, {bool isArticle = false}) {
+    return Container(
+      alignment: Alignment.center,
+      margin: isArticle ? EdgeInsets.zero : const EdgeInsets.symmetric(horizontal: 8),
+      child: Scrollbar(
+        child: SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            children: [
+              _createFooterTextButton(
+                  Icons.mode_comment_outlined,
+                  tweet.replyCount != null ? numberFormat.format(tweet.replyCount) : '',
+                  buttonsColor(context),
+                  () => onClickOpenTweet(tweet)),
+              if (tweet.retweetCount != null && tweet.quoteCount != null)
+                _createFooterTextButton(
+                    Icons.repeat,
+                    numberFormat.format((tweet.retweetCount! + tweet.quoteCount!)),
+                    buttonsColor(context)),
+              if (tweet.favoriteCount != null)
+                _createFooterTextButton(Icons.favorite_border,
+                    numberFormat.format(tweet.favoriteCount), buttonsColor(context)),
+              const SizedBox(
+                width: 8.0,
+              ),
+              Consumer<SavedTweetModel>(builder: (context, model, child) {
+                var isSaved = model.isSaved(tweet.idStr!);
+                if (isSaved) {
+                  return _createFooterIconButton(
+                      Icons.bookmark, Theme.of(context).colorScheme.primary, 1, () async {
+                    await model.deleteSavedTweet(tweet.idStr!);
+                    setState(() {});
+                  });
+                } else {
+                  return _createFooterIconButton(Icons.bookmark_border, buttonsColor(context), 0,
+                      () async {
+                    await model.saveTweet(tweet.idStr!, tweet.user?.idStr, tweet.toJson());
+                    setState(() {});
+                  });
+                }
+              }),
+              _createFooterIconButton(
+                Icons.share,
+                buttonsColor(context),
+                null,
+                () async {
+                  createSheetButton(title, icon, onTap) => ListTile(
+                        onTap: onTap,
+                        leading: Icon(icon),
+                        title: Text(title),
+                      );
+
+                  showModalBottomSheet(
+                      context: context,
+                      builder: (context) {
+                        return SafeArea(
+                            child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            if (!isArticle)
+                              createSheetButton(
+                                L10n.of(context).share_tweet_content,
+                                Icons.text_snippet,
+                                      () async {
+                                    Share.share(tweetText);
+                                    Navigator.pop(context);
+                                  },
+                              ),
+                            createSheetButton(isArticle ? L10n.of(context).share_article_link : L10n.of(context).share_tweet_link, Icons.link,
+                                () async {
+                              Share.share(
+                                  '$shareBaseUrl/${tweet.user!.screenName}/status/${tweet.idStr}');
+                              Navigator.pop(context);
+                            }),
+                            if (!isArticle)
+                              createSheetButton(
+                                  L10n.of(context).share_tweet_content_and_link, Icons.add_link,
+                                      () async {
+                                        Share.share(
+                                            '$tweetText\n\n$shareBaseUrl/${tweet.user!.screenName}/status/${tweet.idStr}');
+                                        Navigator.pop(context);
+                                      }),
+                            createSheetButton(isArticle ? L10n.of(context).share_article_as_image : L10n.of(context).share_tweet_as_image, Icons.screenshot, () async {
+                              Uint8List? imgBytes = await captureWidget();
+                              if (imgBytes != null) {
+                                Share.shareXFiles([XFile.fromData(imgBytes, mimeType: 'image/png')]);
+                              }
+                              Navigator.pop(context);
+                            }),
+                            const Padding(
+                              padding: EdgeInsets.symmetric(horizontal: 16),
+                              child: Divider(
+                                thickness: 1.0,
+                              ),
+                            ),
+                            createSheetButton(
+                              L10n.of(context).cancel,
+                              Icons.close,
+                              () => Navigator.pop(context),
+                            )
+                          ],
+                        ));
+                      });
+                },
+              ),
+              if (!isArticle) _buildTranslateButton(locale),
+            ],
+          ),
+        ),
+      ),
     );
   }
 
@@ -434,29 +569,18 @@ class TweetTileState extends State<TweetTile> with SingleTickerProviderStateMixi
       locale = Locale(splitLocale[0], splitLocale[1]);
     }
 
-    Widget translateButton;
-    switch (_translationStatus) {
-      case TranslationStatus.original:
-        translateButton =
-            _createFooterIconButton(Icons.translate, buttonsColor(context), null, () async => onClickTranslate(context, locale));
-        break;
-      case TranslationStatus.translating:
-        translateButton = const Padding(
-          padding: EdgeInsets.symmetric(horizontal: 24),
-          child: SizedBox(width: 16, height: 16, child: CircularProgressIndicator()),
-        );
-        break;
-      case TranslationStatus.translationFailed:
-        translateButton = _createFooterIconButton(
-            Icons.translate,
-            Colors.red.harmonizeWith(Theme.of(context).colorScheme.primary),
-            null,
-            () async => onClickTranslate(context, locale));
-        break;
-      case TranslationStatus.translated:
-        translateButton = _createFooterIconButton(
-            Icons.translate, Theme.of(context).colorScheme.primary, null, () async => onClickShowOriginal());
-        break;
+    final footerBar = _buildFooterBar(tweet, tweetText, shareBaseUrl, locale, numberFormat, isArticle: tweet.article != null);
+
+    var article = Container();
+    if (tweet.article != null) {
+      article = Container(
+        child: ArticleWidget(
+          article: tweet.article!,
+          expand: widget.tweetOpened,
+          onTap: () => onClickOpenTweet(tweet),
+          bottomBar: widget.tweetOpened ? footerBar : null,
+        )
+      );
     }
 
     DateTime? createdAt;
@@ -550,119 +674,13 @@ class TweetTileState extends State<TweetTile> with SingleTickerProviderStateMixi
                                   child: UserAvatar(uri: tweet.user!.profileImageUrlHttps),
                                 ),
                         ),
-                        content,
+                        if(tweet.article == null) content,
                         media,
                         quotedTweet,
                         TweetCard(tweet: tweet, card: tweet.card),
                         birdwatchQuoted,
-                        Container(
-                          alignment: Alignment.center,
-                          margin: const EdgeInsets.symmetric(horizontal: 8),
-                          child: Scrollbar(
-                            child: SingleChildScrollView(
-                              scrollDirection: Axis.horizontal,
-                              child: Row(
-                                children: [
-                                  _createFooterTextButton(
-                                      Icons.mode_comment_outlined,
-                                      tweet.replyCount != null ? numberFormat.format(tweet.replyCount) : '',
-                                      buttonsColor(context),
-                                      () => onClickOpenTweet(tweet)),
-                                  if (tweet.retweetCount != null && tweet.quoteCount != null)
-                                    _createFooterTextButton(
-                                        Icons.repeat,
-                                        numberFormat.format((tweet.retweetCount! + tweet.quoteCount!)),
-                                        buttonsColor(context)),
-                                  if (tweet.favoriteCount != null)
-                                    _createFooterTextButton(Icons.favorite_border,
-                                        numberFormat.format(tweet.favoriteCount), buttonsColor(context)),
-                                  const SizedBox(
-                                    width: 8.0,
-                                  ),
-                                  Consumer<SavedTweetModel>(builder: (context, model, child) {
-                                    var isSaved = model.isSaved(tweet.idStr!);
-                                    if (isSaved) {
-                                      return _createFooterIconButton(
-                                          Icons.bookmark, Theme.of(context).colorScheme.primary, 1, () async {
-                                        await model.deleteSavedTweet(tweet.idStr!);
-                                        setState(() {});
-                                      });
-                                    } else {
-                                      return _createFooterIconButton(Icons.bookmark_border, buttonsColor(context), 0,
-                                          () async {
-                                        await model.saveTweet(tweet.idStr!, tweet.user?.idStr, tweet.toJson());
-                                        setState(() {});
-                                      });
-                                    }
-                                  }),
-                                  _createFooterIconButton(
-                                    Icons.share,
-                                    buttonsColor(context),
-                                    null,
-                                    () async {
-                                      createSheetButton(title, icon, onTap) => ListTile(
-                                            onTap: onTap,
-                                            leading: Icon(icon),
-                                            title: Text(title),
-                                          );
-
-                                      showModalBottomSheet(
-                                          context: context,
-                                          builder: (context) {
-                                            return SafeArea(
-                                                child: Column(
-                                              mainAxisSize: MainAxisSize.min,
-                                              children: [
-                                                createSheetButton(
-                                                  L10n.of(context).share_tweet_content,
-                                                  Icons.text_snippet,
-                                                      () async {
-                                                    Share.share(tweetText);
-                                                    Navigator.pop(context);
-                                                  },
-                                                ),
-                                                createSheetButton(L10n.of(context).share_tweet_link, Icons.link,
-                                                    () async {
-                                                  Share.share(
-                                                      '$shareBaseUrl/${tweet.user!.screenName}/status/${tweet.idStr}');
-                                                  Navigator.pop(context);
-                                                }),
-                                                createSheetButton(
-                                                    L10n.of(context).share_tweet_content_and_link, Icons.add_link,
-                                                        () async {
-                                                      Share.share(
-                                                          '$tweetText\n\n$shareBaseUrl/${tweet.user!.screenName}/status/${tweet.idStr}');
-                                                      Navigator.pop(context);
-                                                    }),
-                                                createSheetButton(L10n.of(context).share_tweet_as_image, Icons.screenshot, () async {
-                                                  Uint8List? imgBytes = await captureWidget();
-                                                  if (imgBytes != null) {
-                                                    Share.shareXFiles([XFile.fromData(imgBytes, mimeType: 'image/png')]);
-                                                  }
-                                                  Navigator.pop(context);
-                                                }),
-                                                const Padding(
-                                                  padding: EdgeInsets.symmetric(horizontal: 16),
-                                                  child: Divider(
-                                                    thickness: 1.0,
-                                                  ),
-                                                ),
-                                                createSheetButton(
-                                                  L10n.of(context).cancel,
-                                                  Icons.close,
-                                                  () => Navigator.pop(context),
-                                                )
-                                              ],
-                                            ));
-                                          });
-                                    },
-                                  ),
-                                  translateButton,
-                                ],
-                              ),
-                            ),
-                          ),
-                        ),
+                        article,
+                        footerBar,
                       ],
                     ))
                   ],


### PR DESCRIPTION
…videos, code blocks, quotes, links, mentions, titles, ordered lists, unordered lists, bold text, italic text, dividers. Translation is not supported in articles, so "Translate" button is removed on tweets that contain an article. The same way, "Share tweet content" options are not available for articles (text remains selectable). Articles are displayed as a preview when the tweet is not opened. Open the tweet to see the full content. Articles can be saved, but for complexity reasons, only the preview is saved for offline access, network is required to read the full content of a saved article. Please report any issue related to this new feature. It has been implemented by reverse-engineering x.com's APIs based on examples I had access to, some contents might not be parsed correctly. (#53)