### PR TITLE
Add intent filters for fixupx.com URLs

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -101,6 +101,18 @@
                 <data
                     android:host="*vxtwitter.com"
                     android:scheme="https" />
+                
+                <data
+                    android:host="fixupx.com"
+                    android:scheme="http" />
+
+                <data
+                    android:host="fixupx.com"
+                    android:scheme="https" />
+
+                <data
+                    android:host="*fixupx.com"
+                    android:scheme="https" />
 
             </intent-filter>
         </activity>


### PR DESCRIPTION
Fixupx.com (https://github.com/FxEmbed/FxEmbed) Android intent filters was missing. Added in this PR.